### PR TITLE
Update for latest changes with Rust nightly.

### DIFF
--- a/src/bytestr.rs
+++ b/src/bytestr.rs
@@ -27,8 +27,8 @@ pub struct ByteString(Vec<u8>);
 
 impl ByteString {
     /// Create a new byte string from a vector or slice of bytes.
-    pub fn from_bytes<S: CloneableVector<u8>>(bs: S) -> ByteString {
-        ByteString(bs.into_vec())
+    pub fn from_bytes<S: AsSlice<u8>>(bs: S) -> ByteString {
+        ByteString(bs.as_slice().to_vec())
     }
 
     /// Consumes this byte string into a vector of bytes.

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -24,7 +24,7 @@ impl Encoded {
     /// to access the raw CSV record.
     pub fn unwrap(self) -> Vec<ByteString> { self.record }
 
-    fn push_bytes<S: CloneableVector<u8>>(&mut self, s: S) -> CsvResult<()> {
+    fn push_bytes<S: AsSlice<u8>>(&mut self, s: S) -> CsvResult<()> {
         self.record.push(ByteString::from_bytes(s));
         Ok(())
     }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -349,8 +349,8 @@ impl Reader<MemReader> {
     }
 
     /// Creates a CSV reader for an in memory buffer of bytes.
-    pub fn from_bytes<V: CloneableVector<u8>>(bytes: V) -> Reader<MemReader> {
-        Reader::from_reader(MemReader::new(bytes.into_vec()))
+    pub fn from_bytes<V: AsSlice<u8>>(bytes: V) -> Reader<MemReader> {
+        Reader::from_reader(MemReader::new(bytes.as_slice().to_vec()))
     }
 }
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -9,7 +9,7 @@ fn ordie<T, E: ::std::fmt::Show>(res: Result<T, E>) -> T {
     }
 }
 
-fn bytes<S: CloneableVector<u8>>(bs: S) -> ByteString {
+fn bytes<S: AsSlice<u8>>(bs: S) -> ByteString {
     ByteString::from_bytes(bs)
 }
 


### PR DESCRIPTION
Latest update has modified the CloneableVector trait, and as a result, Vec<T> is no longer an implementor of CloneableVector<T>. To fix this, use AsSlice<T> instead and convert slice/vector to slice, and then call Vec::to_vec() on the result.

I don't know whether this is the best approach as I've only used Rust for a week or so. :-)
