### PR TITLE
Fix the case when CSV file has \r only line endings.

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -489,6 +489,11 @@ impl<R: io::Reader> Reader<R> {
             // After processing an EndRecord (and determined there are no
             // errors), we should always start parsing the next record.
             self.state = StartRecord;
+            // If the record has ended, but the line_current didn't increment (possible if we have \r line endings) then increment it here.
+            if self.line_record == self.line_current {
+                self.line_current += 1;
+                self.column = 1;
+            }
             self.line_record = self.line_current;
             self.field_count = 0;
             return None;

--- a/src/test.rs
+++ b/src/test.rs
@@ -121,6 +121,14 @@ fn decoder_simple_crlf() {
 }
 
 #[test]
+fn decoder_simple_cr() {
+    let mut d = Reader::from_string("springsteen,s,1,0.1,false\rreevolver,b,0,1.0,true\r")
+                       .has_headers(false);
+    let r: Vec<(String, char, int, f64, bool)> = collect(d.decode());
+    assert_eq!(r, vec![("springsteen".to_string(), 's', 1, 0.1, false), ("reevolver".to_string(), 'b', 0, 1.0, true)]);
+}
+
+#[test]
 fn decoder_simple_tabbed() {
     let mut d = Reader::from_string("springsteen\ts\t1\t0.14\tfalse\r\n")
                        .has_headers(false)


### PR DESCRIPTION
Excel creates those when you export CSV.
The problem was that the line_current didn't increment (because it never met \n),
so it was copying everything into first_record.
