### PR TITLE
Implemented Copy.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -248,7 +248,7 @@ impl Error {
 }
 
 /// A description of a CSV parse error.
-#[deriving(Clone)]
+#[deriving(Clone, Copy)]
 pub struct ParseError {
     /// The line number of the parse error.
     pub line: u64,
@@ -266,7 +266,7 @@ pub struct ParseError {
 ///
 /// If and when a "strict" mode is added to this crate, this list of errors
 /// will expand.
-#[deriving(Clone)]
+#[deriving(Clone, Copy)]
 pub enum ParseErrorKind {
     /// This error occurs when a record has a different number of fields
     /// than the first record parsed.

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -21,6 +21,7 @@ use self::ParseState::{
 ///
 /// Generally, you won't need to use this type because `CRLF` is the default,
 /// which is by far the most widely used record terminator.
+#[deriving(Copy)]
 pub enum RecordTerminator {
     /// Parses `\r`, `\n` or `\r\n` as a single record terminator.
     CRLF,

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -7,6 +7,7 @@ use serialize::Encodable;
 use {ByteString, CsvResult, Encoded, Error, RecordTerminator};
 
 /// The quoting style to use when writing CSV data.
+#[deriving(Copy)]
 pub enum QuoteStyle {
     /// This puts quotes around every field. Always.
     Always,


### PR DESCRIPTION
Implemented Copy for ParseError, ParseErrorKind, RecordTerminator and
QuoteStyle.

This fixes an issue with the latest version of rust (rustc 0.13.0-dev (8fbfa66b4 2014-12-09 21:56:13 +0000)) which causes:

```
src/reader.rs:649:32 649:36 error:  cannot move out of dereference of `&mut`-pointer
```
