### PR TITLE
Two fixes for changes in rust and in serialize crate.

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -104,9 +104,9 @@ impl serialize::Decoder<Error> for Decoded {
             where F: FnOnce(&mut Decoded) -> CsvResult<T> {
         f(self)
     }
-    fn read_enum_variant<T, F>(&mut self, names: &[&str], f: F)
+    fn read_enum_variant<T, F>(&mut self, names: &[&str], mut f: F)
                               -> CsvResult<T>
-            where F: FnOnce(&mut Decoded, uint) -> CsvResult<T> {
+            where F: FnMut(&mut Decoded, uint) -> CsvResult<T> {
         let variant = to_lower(try!(self.pop_string()).as_slice());
         match names.iter().position(|&name| to_lower(name) == variant) {
             Some(idx) => f(self, idx),
@@ -121,7 +121,7 @@ impl serialize::Decoder<Error> for Decoded {
     }
     fn read_enum_struct_variant<T, F>(&mut self, names: &[&str], f: F)
                                      -> CsvResult<T>
-            where F: FnOnce(&mut Decoded, uint) -> CsvResult<T> {
+            where F: FnMut(&mut Decoded, uint) -> CsvResult<T> {
         self.read_enum_variant(names, f)
     }
     fn read_enum_struct_variant_field<T, F>(&mut self, _: &str,
@@ -163,8 +163,8 @@ impl serialize::Decoder<Error> for Decoded {
             where F: FnOnce(&mut Decoded) -> CsvResult<T> {
         unimplemented!()
     }
-    fn read_option<T, F>(&mut self, f: F) -> CsvResult<T>
-            where F: FnOnce(&mut Decoded, bool) -> CsvResult<T> {
+    fn read_option<T, F>(&mut self, mut f: F) -> CsvResult<T>
+            where F: FnMut(&mut Decoded, bool) -> CsvResult<T> {
         let s = try!(self.pop_string());
         if s.is_empty() {
             f(self, false)

--- a/src/test.rs
+++ b/src/test.rs
@@ -28,7 +28,7 @@ fn assert_svec_eq<S: Str, T: Str>(got: Vec<Vec<S>>, expected: Vec<Vec<T>>) {
 
 macro_rules! parses_to {
     ($name:ident, $csv:expr, $vec:expr) => (
-        parses_to!($name, $csv, $vec, |rdr| rdr)
+        parses_to!($name, $csv, $vec, |rdr| rdr);
     );
     ($name:ident, $csv:expr, $vec:expr, $config:expr) => (
         #[test]
@@ -45,7 +45,7 @@ macro_rules! parses_to {
 
 macro_rules! fail_parses_to {
     ($name:ident, $csv:expr, $vec:expr) => (
-        fail_parses_to!($name, $csv, $vec, |rdr| rdr)
+        fail_parses_to!($name, $csv, $vec, |rdr| rdr);
     );
     ($name:ident, $csv:expr, $vec:expr, $config:expr) => (
         #[test]
@@ -63,7 +63,7 @@ macro_rules! fail_parses_to {
 
 macro_rules! decodes_to {
     ($name:ident, $csv:expr, $ty:ty, $vec:expr) => (
-        decodes_to!($name, $csv, $ty, $vec, false)
+        decodes_to!($name, $csv, $ty, $vec, false);
     );
     ($name:ident, $csv:expr, $ty:ty, $vec:expr, $headers:expr) => (
         #[test]
@@ -80,7 +80,7 @@ macro_rules! decodes_to {
 
 macro_rules! writes_as {
     ($name:ident, $vec:expr, $csv:expr) => (
-        writes_as!($name, $vec, $csv, |wtr| wtr)
+        writes_as!($name, $vec, $csv, |wtr| wtr);
     );
     ($name:ident, $vec:expr, $csv:expr, $config:expr) => (
         #[test]
@@ -96,7 +96,7 @@ macro_rules! writes_as {
 
 macro_rules! fail_writes_as {
     ($name:ident, $vec:expr, $csv:expr) => (
-        fail_writes_as!($name, $vec, $csv, |wtr| wtr)
+        fail_writes_as!($name, $vec, $csv, |wtr| wtr);
     );
     ($name:ident, $vec:expr, $csv:expr, $config:expr) => (
         #[test]
@@ -124,204 +124,204 @@ macro_rules! encodes_as {
     );
 }
 
-parses_to!(one_row_one_field, "a", vec![vec!["a"]])
-parses_to!(one_row_many_fields, "a,b,c", vec![vec!["a", "b", "c"]])
-parses_to!(one_row_trailing_comma, "a,b,", vec![vec!["a", "b", ""]])
-parses_to!(one_row_one_field_lf, "a\n", vec![vec!["a"]])
-parses_to!(one_row_many_fields_lf, "a,b,c\n", vec![vec!["a", "b", "c"]])
-parses_to!(one_row_trailing_comma_lf, "a,b,\n", vec![vec!["a", "b", ""]])
-parses_to!(one_row_one_field_crlf, "a\r\n", vec![vec!["a"]])
-parses_to!(one_row_many_fields_crlf, "a,b,c\r\n", vec![vec!["a", "b", "c"]])
-parses_to!(one_row_trailing_comma_crlf, "a,b,\r\n", vec![vec!["a", "b", ""]])
-parses_to!(one_row_one_field_cr, "a\r", vec![vec!["a"]])
-parses_to!(one_row_many_fields_cr, "a,b,c\r", vec![vec!["a", "b", "c"]])
-parses_to!(one_row_trailing_comma_cr, "a,b,\r", vec![vec!["a", "b", ""]])
+parses_to!(one_row_one_field, "a", vec![vec!["a"]]);
+parses_to!(one_row_many_fields, "a,b,c", vec![vec!["a", "b", "c"]]);
+parses_to!(one_row_trailing_comma, "a,b,", vec![vec!["a", "b", ""]]);
+parses_to!(one_row_one_field_lf, "a\n", vec![vec!["a"]]);
+parses_to!(one_row_many_fields_lf, "a,b,c\n", vec![vec!["a", "b", "c"]]);
+parses_to!(one_row_trailing_comma_lf, "a,b,\n", vec![vec!["a", "b", ""]]);
+parses_to!(one_row_one_field_crlf, "a\r\n", vec![vec!["a"]]);
+parses_to!(one_row_many_fields_crlf, "a,b,c\r\n", vec![vec!["a", "b", "c"]]);
+parses_to!(one_row_trailing_comma_crlf, "a,b,\r\n", vec![vec!["a", "b", ""]]);
+parses_to!(one_row_one_field_cr, "a\r", vec![vec!["a"]]);
+parses_to!(one_row_many_fields_cr, "a,b,c\r", vec![vec!["a", "b", "c"]]);
+parses_to!(one_row_trailing_comma_cr, "a,b,\r", vec![vec!["a", "b", ""]]);
 
-parses_to!(many_rows_one_field, "a\nb", vec![vec!["a"], vec!["b"]])
+parses_to!(many_rows_one_field, "a\nb", vec![vec!["a"], vec!["b"]]);
 parses_to!(many_rows_many_fields,
-           "a,b,c\nx,y,z", vec![vec!["a", "b", "c"], vec!["x", "y", "z"]])
+           "a,b,c\nx,y,z", vec![vec!["a", "b", "c"], vec!["x", "y", "z"]]);
 parses_to!(many_rows_trailing_comma,
-           "a,b,\nx,y,", vec![vec!["a", "b", ""], vec!["x", "y", ""]])
-parses_to!(many_rows_one_field_lf, "a\nb\n", vec![vec!["a"], vec!["b"]])
+           "a,b,\nx,y,", vec![vec!["a", "b", ""], vec!["x", "y", ""]]);
+parses_to!(many_rows_one_field_lf, "a\nb\n", vec![vec!["a"], vec!["b"]]);
 parses_to!(many_rows_many_fields_lf,
-           "a,b,c\nx,y,z\n", vec![vec!["a", "b", "c"], vec!["x", "y", "z"]])
+           "a,b,c\nx,y,z\n", vec![vec!["a", "b", "c"], vec!["x", "y", "z"]]);
 parses_to!(many_rows_trailing_comma_lf,
-           "a,b,\nx,y,\n", vec![vec!["a", "b", ""], vec!["x", "y", ""]])
-parses_to!(many_rows_one_field_crlf, "a\r\nb\r\n", vec![vec!["a"], vec!["b"]])
+           "a,b,\nx,y,\n", vec![vec!["a", "b", ""], vec!["x", "y", ""]]);
+parses_to!(many_rows_one_field_crlf, "a\r\nb\r\n", vec![vec!["a"], vec!["b"]]);
 parses_to!(many_rows_many_fields_crlf,
            "a,b,c\r\nx,y,z\r\n",
-           vec![vec!["a", "b", "c"], vec!["x", "y", "z"]])
+           vec![vec!["a", "b", "c"], vec!["x", "y", "z"]]);
 parses_to!(many_rows_trailing_comma_crlf,
-           "a,b,\r\nx,y,\r\n", vec![vec!["a", "b", ""], vec!["x", "y", ""]])
-parses_to!(many_rows_one_field_cr, "a\rb\r", vec![vec!["a"], vec!["b"]])
+           "a,b,\r\nx,y,\r\n", vec![vec!["a", "b", ""], vec!["x", "y", ""]]);
+parses_to!(many_rows_one_field_cr, "a\rb\r", vec![vec!["a"], vec!["b"]]);
 parses_to!(many_rows_many_fields_cr,
-           "a,b,c\rx,y,z\r", vec![vec!["a", "b", "c"], vec!["x", "y", "z"]])
+           "a,b,c\rx,y,z\r", vec![vec!["a", "b", "c"], vec!["x", "y", "z"]]);
 parses_to!(many_rows_trailing_comma_cr,
-           "a,b,\rx,y,\r", vec![vec!["a", "b", ""], vec!["x", "y", ""]])
+           "a,b,\rx,y,\r", vec![vec!["a", "b", ""], vec!["x", "y", ""]]);
 
 parses_to!(trailing_lines_no_record,
            "\n\n\na,b,c\nx,y,z\n\n\n",
-           vec![vec!["a", "b", "c"], vec!["x", "y", "z"]])
+           vec![vec!["a", "b", "c"], vec!["x", "y", "z"]]);
 parses_to!(trailing_lines_no_record_cr,
            "\r\r\ra,b,c\rx,y,z\r\r\r",
-           vec![vec!["a", "b", "c"], vec!["x", "y", "z"]])
+           vec![vec!["a", "b", "c"], vec!["x", "y", "z"]]);
 parses_to!(trailing_lines_no_record_crlf,
            "\r\n\r\n\r\na,b,c\r\nx,y,z\r\n\r\n\r\n",
-           vec![vec!["a", "b", "c"], vec!["x", "y", "z"]])
-parses_to!(empty_string_no_headers, "", vec![])
+           vec![vec!["a", "b", "c"], vec!["x", "y", "z"]]);
+parses_to!(empty_string_no_headers, "", vec![]);
 parses_to!(empty_string_headers, "", vec![],
-           |rdr: Reader<_>| rdr.has_headers(true))
-parses_to!(empty_lines, "\n\n\n\n", vec![])
+           |rdr: Reader<_>| rdr.has_headers(true));
+parses_to!(empty_lines, "\n\n\n\n", vec![]);
 parses_to!(empty_lines_interspersed, "\n\na,b\n\n\nx,y\n\n\nm,n\n",
-           vec![vec!["a", "b"], vec!["x", "y"], vec!["m", "n"]])
-parses_to!(empty_lines_crlf, "\r\n\r\n\r\n\r\n", vec![])
+           vec![vec!["a", "b"], vec!["x", "y"], vec!["m", "n"]]);
+parses_to!(empty_lines_crlf, "\r\n\r\n\r\n\r\n", vec![]);
 parses_to!(empty_lines_interspersed_crlf,
            "\r\n\r\na,b\r\n\r\n\r\nx,y\r\n\r\n\r\nm,n\r\n",
-           vec![vec!["a", "b"], vec!["x", "y"], vec!["m", "n"]])
-parses_to!(empty_lines_mixed, "\r\n\n\r\n\n", vec![])
+           vec![vec!["a", "b"], vec!["x", "y"], vec!["m", "n"]]);
+parses_to!(empty_lines_mixed, "\r\n\n\r\n\n", vec![]);
 parses_to!(empty_lines_interspersed_mixed,
            "\n\r\na,b\r\n\n\r\nx,y\r\n\n\r\nm,n\r\n",
-           vec![vec!["a", "b"], vec!["x", "y"], vec!["m", "n"]])
-parses_to!(empty_lines_cr, "\r\r\r\r", vec![])
+           vec![vec!["a", "b"], vec!["x", "y"], vec!["m", "n"]]);
+parses_to!(empty_lines_cr, "\r\r\r\r", vec![]);
 parses_to!(empty_lines_interspersed_cr, "\r\ra,b\r\r\rx,y\r\r\rm,n\r",
-           vec![vec!["a", "b"], vec!["x", "y"], vec!["m", "n"]])
+           vec![vec!["a", "b"], vec!["x", "y"], vec!["m", "n"]]);
 
 parses_to!(term_weird, "zza,bzc,dzz", vec![vec!["a", "b"], vec!["c", "d"]],
-           |rdr: Reader<_>| rdr.record_terminator(RecordTerminator::Any(b'z')))
+           |rdr: Reader<_>| rdr.record_terminator(RecordTerminator::Any(b'z')));
 
 parses_to!(ascii_delimited, "a\x1fb\x1ec\x1fd",
            vec![vec!["a", "b"], vec!["c", "d"]],
            |rdr: Reader<_>| {
                rdr.delimiter(b'\x1f')
                   .record_terminator(RecordTerminator::Any(b'\x1e'))
-           })
+           });
 
-parses_to!(quote_empty, "\"\"", vec![vec![""]])
-parses_to!(quote_lf, "\"\"\n", vec![vec![""]])
-parses_to!(quote_space, "\" \"", vec![vec![" "]])
-parses_to!(quote_inner_space, "\" a \"", vec![vec![" a "]])
-parses_to!(quote_outer_space, "  \"a\"  ", vec![vec!["  \"a\"  "]])
+parses_to!(quote_empty, "\"\"", vec![vec![""]]);
+parses_to!(quote_lf, "\"\"\n", vec![vec![""]]);
+parses_to!(quote_space, "\" \"", vec![vec![" "]]);
+parses_to!(quote_inner_space, "\" a \"", vec![vec![" a "]]);
+parses_to!(quote_outer_space, "  \"a\"  ", vec![vec!["  \"a\"  "]]);
 
 parses_to!(quote_change, "zaz", vec![vec!["a"]],
-           |rdr: Reader<_>| rdr.quote(Some(b'z')))
+           |rdr: Reader<_>| rdr.quote(Some(b'z')));
 
 // This one is pretty hokey. I don't really know what the "right" behavior is.
 parses_to!(quote_delimiter, ",a,,b", vec![vec!["a,b"]],
-           |rdr: Reader<_>| rdr.quote(Some(b',')))
+           |rdr: Reader<_>| rdr.quote(Some(b',')));
 
 // Another hokey one...
-parses_to!(quote_no_escapes, r#""a\"b""#, vec![vec![r#"a\b""#]])
+parses_to!(quote_no_escapes, r#""a\"b""#, vec![vec![r#"a\b""#]]);
 parses_to!(quote_escapes_no_double, r#""a""b""#, vec![vec![r#"a"b""#]],
-           |rdr: Reader<_>| rdr.double_quote(false))
+           |rdr: Reader<_>| rdr.double_quote(false));
 parses_to!(quote_escapes, r#""a\"b""#, vec![vec![r#"a"b"#]],
-           |rdr: Reader<_>| rdr.double_quote(false))
+           |rdr: Reader<_>| rdr.double_quote(false));
 parses_to!(quote_escapes_change, r#""az"b""#, vec![vec![r#"a"b"#]],
-           |rdr: Reader<_>| rdr.double_quote(false).escape(b'z'))
+           |rdr: Reader<_>| rdr.double_quote(false).escape(b'z'));
 
 parses_to!(delimiter_tabs, "a\tb", vec![vec!["a", "b"]],
-           |rdr: Reader<_>| rdr.delimiter(b'\t'))
+           |rdr: Reader<_>| rdr.delimiter(b'\t'));
 parses_to!(delimiter_weird, "azb", vec![vec!["a", "b"]],
-           |rdr: Reader<_>| rdr.delimiter(b'z'))
+           |rdr: Reader<_>| rdr.delimiter(b'z'));
 
 parses_to!(headers_absent, "a\nb", vec![vec!["b"]],
-           |rdr: Reader<_>| rdr.has_headers(true))
+           |rdr: Reader<_>| rdr.has_headers(true));
 
 parses_to!(flexible_rows, "a\nx,y", vec![vec!["a"], vec!["x", "y"]],
-           |rdr: Reader<_>| rdr.flexible(true))
+           |rdr: Reader<_>| rdr.flexible(true));
 parses_to!(flexible_rows2, "a,b\nx", vec![vec!["a", "b"], vec!["x"]],
-           |rdr: Reader<_>| rdr.flexible(true))
+           |rdr: Reader<_>| rdr.flexible(true));
 
-fail_parses_to!(nonflexible, "a\nx,y", vec![])
-fail_parses_to!(nonflexible2, "a,b\nx", vec![])
+fail_parses_to!(nonflexible, "a\nx,y", vec![]);
+fail_parses_to!(nonflexible2, "a,b\nx", vec![]);
 
 #[deriving(Decodable, Encodable, Show, PartialEq, Eq)]
 enum Color { Red, Blue, Green }
 
-decodes_to!(decode_int, "1", (uint,), vec![(1u,)])
-decodes_to!(decode_many_int, "1,2", (uint, i16), vec![(1u,2i16)])
-decodes_to!(decode_float, "1,1.0,1.5", (f64, f64, f64), vec![(1f64, 1.0, 1.5)])
-decodes_to!(decode_char, "a", (char,), vec![('a',)])
-decodes_to!(decode_str, "abc", (String,), vec![("abc".into_string(),)])
+decodes_to!(decode_int, "1", (uint,), vec![(1u,)]);
+decodes_to!(decode_many_int, "1,2", (uint, i16), vec![(1u,2i16)]);
+decodes_to!(decode_float, "1,1.0,1.5", (f64, f64, f64), vec![(1f64, 1.0, 1.5)]);
+decodes_to!(decode_char, "a", (char,), vec![('a',)]);
+decodes_to!(decode_str, "abc", (String,), vec![("abc".into_string(),)]);
 
-decodes_to!(decode_opt_int, "\"\"", (Option<uint>,), vec![(None,)])
-decodes_to!(decode_opt_float, "\"\"", (Option<f64>,), vec![(None,)])
-decodes_to!(decode_opt_char, "\"\"", (Option<char>,), vec![(None,)])
-decodes_to!(decode_opt_empty, "\"\"", (Option<String>,), vec![(None,)])
+decodes_to!(decode_opt_int, "\"\"", (Option<uint>,), vec![(None,)]);
+decodes_to!(decode_opt_float, "\"\"", (Option<f64>,), vec![(None,)]);
+decodes_to!(decode_opt_char, "\"\"", (Option<char>,), vec![(None,)]);
+decodes_to!(decode_opt_empty, "\"\"", (Option<String>,), vec![(None,)]);
 
 decodes_to!(decode_color, "red,Blue,GrEeN", (Color, Color, Color),
-            vec![(Color::Red, Color::Blue, Color::Green)])
-decodes_to!(decode_opt_color, "\"\"", (Option<Color>,), vec![(None,)])
+            vec![(Color::Red, Color::Blue, Color::Green)]);
+decodes_to!(decode_opt_color, "\"\"", (Option<Color>,), vec![(None,)]);
 
 decodes_to!(decode_tail, "abc,1,2,3,4", (String, Vec<uint>),
-            vec![("abc".into_string(), vec![1u, 2, 3, 4])])
+            vec![("abc".into_string(), vec![1u, 2, 3, 4])]);
 
-writes_as!(wtr_one_record_one_field, vec![vec!["a"]], "a\n")
-writes_as!(wtr_one_record_many_field, vec![vec!["a", "b"]], "a,b\n")
-writes_as!(wtr_many_record_one_field, vec![vec!["a"], vec!["b"]], "a\nb\n")
+writes_as!(wtr_one_record_one_field, vec![vec!["a"]], "a\n");
+writes_as!(wtr_one_record_many_field, vec![vec!["a", "b"]], "a,b\n");
+writes_as!(wtr_many_record_one_field, vec![vec!["a"], vec!["b"]], "a\nb\n");
 writes_as!(wtr_many_record_many_field,
-           vec![vec!["a", "b"], vec!["x", "y"]], "a,b\nx,y\n")
+           vec![vec!["a", "b"], vec!["x", "y"]], "a,b\nx,y\n");
 writes_as!(wtr_one_record_one_field_crlf, vec![vec!["a"]], "a\r\n",
-           |wtr: Writer<_>| wtr.record_terminator(RecordTerminator::CRLF))
+           |wtr: Writer<_>| wtr.record_terminator(RecordTerminator::CRLF));
 writes_as!(wtr_one_record_many_field_crlf, vec![vec!["a", "b"]], "a,b\r\n",
-           |wtr: Writer<_>| wtr.record_terminator(RecordTerminator::CRLF))
+           |wtr: Writer<_>| wtr.record_terminator(RecordTerminator::CRLF));
 writes_as!(wtr_many_record_one_field_crlf,
            vec![vec!["a"], vec!["b"]], "a\r\nb\r\n",
-           |wtr: Writer<_>| wtr.record_terminator(RecordTerminator::CRLF))
+           |wtr: Writer<_>| wtr.record_terminator(RecordTerminator::CRLF));
 writes_as!(wtr_many_record_many_field_crlf,
            vec![vec!["a", "b"], vec!["x", "y"]], "a,b\r\nx,y\r\n",
-           |wtr: Writer<_>| wtr.record_terminator(RecordTerminator::CRLF))
+           |wtr: Writer<_>| wtr.record_terminator(RecordTerminator::CRLF));
 
 writes_as!(wtr_tabs, vec![vec!["a", "b"]], "a\tb\n",
-           |wtr: Writer<_>| wtr.delimiter(b'\t'))
+           |wtr: Writer<_>| wtr.delimiter(b'\t'));
 writes_as!(wtr_weird, vec![vec!["a", "b"]], "azb\n",
-           |wtr: Writer<_>| wtr.delimiter(b'z'))
+           |wtr: Writer<_>| wtr.delimiter(b'z'));
 writes_as!(wtr_flexible, vec![vec!["a"], vec!["a", "b"]], "a\na,b\n",
-           |wtr: Writer<_>| wtr.flexible(true))
+           |wtr: Writer<_>| wtr.flexible(true));
 writes_as!(wtr_flexible2, vec![vec!["a", "b"], vec!["a"]], "a,b\na\n",
-           |wtr: Writer<_>| wtr.flexible(true))
+           |wtr: Writer<_>| wtr.flexible(true));
 
-writes_as!(wtr_quoted_lf, vec![vec!["a\n"]], "\"a\n\"\n")
-writes_as!(wtr_quoted_cr, vec![vec!["a\r"]], "\"a\r\"\n")
+writes_as!(wtr_quoted_lf, vec![vec!["a\n"]], "\"a\n\"\n");
+writes_as!(wtr_quoted_cr, vec![vec!["a\r"]], "\"a\r\"\n");
 writes_as!(wtr_quoted_quotes, vec![vec!["\"a\""]], r#""""a"""
-"#)
-writes_as!(wtr_quoted_delim, vec![vec!["a,b"]], "\"a,b\"\n")
+"#);
+writes_as!(wtr_quoted_delim, vec![vec!["a,b"]], "\"a,b\"\n");
 
-writes_as!(wtr_empty_row, vec![vec![""]], "\"\"\n")
+writes_as!(wtr_empty_row, vec![vec![""]], "\"\"\n");
 writes_as!(wtr_empty_rows, vec![vec![""], vec!["a"], vec![""]],
-           "\"\"\na\n\"\"\n")
-writes_as!(wtr_empty_field_one_row, vec![vec!["", "a"]], ",a\n")
+           "\"\"\na\n\"\"\n");
+writes_as!(wtr_empty_field_one_row, vec![vec!["", "a"]], ",a\n");
 writes_as!(wtr_empty_field_rows,
            vec![vec!["", "a"], vec!["a", "b"], vec!["", "a"]],
-           ",a\na,b\n,a\n")
+           ",a\na,b\n,a\n");
 
 writes_as!(wtr_always_quote, vec![vec!["a"]], "\"a\"\n",
-           |wtr: Writer<_>| wtr.quote_style(QuoteStyle::Always))
+           |wtr: Writer<_>| wtr.quote_style(QuoteStyle::Always));
 writes_as!(wtr_never_quote, vec![vec!["a"]], "a\n",
-           |wtr: Writer<_>| wtr.quote_style(QuoteStyle::Never))
+           |wtr: Writer<_>| wtr.quote_style(QuoteStyle::Never));
 
 writes_as!(wtr_escape, vec![vec!["a\"b"]], "\"a\\\"b\"\n",
-           |wtr: Writer<_>| wtr.double_quote(false))
+           |wtr: Writer<_>| wtr.double_quote(false));
 writes_as!(wtr_escape_weird, vec![vec!["a\"b"]], "\"az\"b\"\n",
-           |wtr: Writer<_>| wtr.double_quote(false).escape(b'z'))
+           |wtr: Writer<_>| wtr.double_quote(false).escape(b'z'));
 
 writes_as!(wtr_quote_weird, vec![vec!["a,b"]], "za,bz\n",
-           |wtr: Writer<_>| wtr.quote(b'z'))
+           |wtr: Writer<_>| wtr.quote(b'z'));
 
 fail_writes_as!(wtr_no_rows,
-                { let rows: Vec<Vec<&str>> = vec![vec![]]; rows }, "")
-fail_writes_as!(wtr_noflexible, vec![vec!["a"], vec!["a", "b"]], "a\na,b\n")
-fail_writes_as!(wtr_noflexible2, vec![vec!["a", "b"], vec!["a"]], "a,b\na\n")
+                { let rows: Vec<Vec<&str>> = vec![vec![]]; rows }, "");
+fail_writes_as!(wtr_noflexible, vec![vec!["a"], vec!["a", "b"]], "a\na,b\n");
+fail_writes_as!(wtr_noflexible2, vec![vec!["a", "b"], vec!["a"]], "a,b\na\n");
 fail_writes_as!(wtr_never_quote_needs_quotes, vec![vec![","]], "\",\"",
-                |wtr: Writer<_>| wtr.quote_style(QuoteStyle::Never))
+                |wtr: Writer<_>| wtr.quote_style(QuoteStyle::Never));
 
-encodes_as!(encode_int, vec![(1u,)], "1\n")
-encodes_as!(encode_many_int, vec![(1u, 2i16)], "1,2\n")
-encodes_as!(encode_float, vec![(1f64, 1.0f64, 1.5f64)], "1,1,1.5\n")
-encodes_as!(encode_char, vec![('a',)], "a\n")
-encodes_as!(encode_none, vec![(None::<bool>,)], "\"\"\n")
-encodes_as!(encode_some, vec![(Some(true),)], "true\n")
+encodes_as!(encode_int, vec![(1u,)], "1\n");
+encodes_as!(encode_many_int, vec![(1u, 2i16)], "1,2\n");
+encodes_as!(encode_float, vec![(1f64, 1.0f64, 1.5f64)], "1,1,1.5\n");
+encodes_as!(encode_char, vec![('a',)], "a\n");
+encodes_as!(encode_none, vec![(None::<bool>,)], "\"\"\n");
+encodes_as!(encode_some, vec![(Some(true),)], "true\n");
 encodes_as!(encode_color, vec![(Color::Red, Color::Blue, Color::Green)],
-            "Red,Blue,Green\n")
+            "Red,Blue,Green\n");
 
 #[test]
 fn no_headers_no_skip_one_record() {


### PR DESCRIPTION
Have a fix for breaking change introduce in rust commit rust-lang/rust@ddb2466 which
now parses `macro!()` and `macro![]` as expressions if not followed by a
semi-colon.

Also fixed a change in the Serialize crate resulting in FnMut being used
instead of FnOnce (following rust-lang/rust@c9ea7c9).
