### PR TITLE
rustup - fix mutable slice syntax.

### DIFF
--- a/src/buffered.rs
+++ b/src/buffered.rs
@@ -50,7 +50,7 @@ impl<R: Reader> BufferedReader<R> {
 impl<R: Reader> Buffer for BufferedReader<R> {
     fn fill_buf<'a>(&'a mut self) -> IoResult<&'a [u8]> {
         if self.pos == self.cap {
-            self.cap = try!(self.inner.read(self.buf[mut]));
+            self.cap = try!(self.inner.read(self.buf.as_mut_slice()));
             self.pos = 0;
         }
         Ok(self.buf[self.pos..self.cap])


### PR DESCRIPTION
Following https://github.com/rust-lang/rust/commit/4e2afb0052618ca3d758fffd0cf50559be774391, unfortunately mutability couldn't be inferred here and calling `as_mut_slice` was necessary.
