### PR TITLE
Update to latest Rust.

### DIFF
--- a/src/bench.rs
+++ b/src/bench.rs
@@ -1,5 +1,5 @@
 use std::fmt::Show;
-use std::io::{mod, ByRefReader};
+use std::io::{self, ByRefReader};
 use std::io::Reader as IoReader;
 use stdtest::Bencher;
 

--- a/src/bytestr.rs
+++ b/src/bytestr.rs
@@ -1,6 +1,7 @@
-use std::borrow::{BorrowFrom, Cow, ToOwned};
+use std::borrow::{BorrowFrom, Cow, IntoCow, ToOwned};
 use std::fmt;
 use std::hash;
+use std::iter::FromIterator;
 use std::ops;
 
 /// A trait that encapsulates a `Vec<T>` or a `&[T]`.
@@ -109,7 +110,7 @@ impl<'a> StrAllocating for &'a str {
 /// encoding, but they also expose some lower level methods that use byte
 /// strings when absolutely necessary. This type is exposed in case you need
 /// to deal with the raw bytes directly.
-#[deriving(Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ByteString(Vec<u8>);
 
 impl ByteString {
@@ -170,7 +171,8 @@ impl AsSlice<u8> for ByteString {
     }
 }
 
-impl Deref<[u8]> for ByteString {
+impl ops::Deref for ByteString {
+    type Target = [u8];
     fn deref<'a>(&'a self) -> &'a [u8] {
         &*self.0
     }

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -61,7 +61,7 @@ impl serialize::Encoder<Error> for Encoded {
         self.push_string(::std::f32::to_str_digits(v, 10))
     }
     fn emit_char(&mut self, v: char) -> CsvResult<()> {
-        let mut bytes = [0u8, ..4];
+        let mut bytes = [0u8; 4];
         let n = v.encode_utf8(bytes.as_mut_slice()).unwrap_or(0);
         self.push_bytes(bytes.slice_to(n))
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,10 @@
 #![experimental]
 #![deny(missing_docs)]
 
-#![feature(default_type_params, macro_rules, slicing_syntax)]
+#![feature(default_type_params, macro_rules, slicing_syntax, associated_types)]
+
+// FIXME: Temporary fix until associated types are fully baked (especially with Hash).
+#![feature(old_orphan_check)]
 
 //! This crate provides a streaming CSV (comma separated values) writer and
 //! reader that works with the `serialize` crate to do type based encoding
@@ -220,7 +223,7 @@ mod test;
 pub type CsvResult<T> = Result<T, Error>;
 
 /// An error produced by an operation on CSV data.
-#[deriving(Clone)]
+#[derive(Clone)]
 pub enum Error {
     /// An error reported by the type-based encoder.
     Encode(String),
@@ -245,7 +248,7 @@ impl Error {
 }
 
 /// A description of a CSV parse error.
-#[deriving(Clone, Copy)]
+#[derive(Clone, Copy)]
 pub struct ParseError {
     /// The line number of the parse error.
     pub line: u64,
@@ -263,7 +266,7 @@ pub struct ParseError {
 ///
 /// If and when a "strict" mode is added to this crate, this list of errors
 /// will expand.
-#[deriving(Clone, Copy)]
+#[derive(Clone, Copy)]
 pub enum ParseErrorKind {
     /// This error occurs when a record has a different number of fields
     /// than the first record parsed.

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1,4 +1,4 @@
-use std::io::{mod, MemReader};
+use std::io::{self, MemReader};
 
 use rustc_serialize::Decodable;
 
@@ -22,7 +22,7 @@ use self::ParseState::{
 ///
 /// Generally, you won't need to use this type because `CRLF` is the default,
 /// which is by far the most widely used record terminator.
-#[deriving(Copy)]
+#[derive(Copy)]
 pub enum RecordTerminator {
     /// Parses `\r`, `\n` or `\r\n` as a single record terminator.
     CRLF,
@@ -801,7 +801,7 @@ impl<R: io::Reader + io::Seek> Reader<R> {
     }
 }
 
-#[deriving(Copy)]
+#[derive(Copy)]
 struct ParseMachine {
     delimiter: u8,
     record_terminator: RecordTerminator,
@@ -810,7 +810,7 @@ struct ParseMachine {
     double_quote: bool,
 }
 
-#[deriving(Copy, Eq, PartialEq, Show)]
+#[derive(Copy, Eq, PartialEq, Show)]
 enum ParseState {
     StartRecord,
     EndRecord,

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -10,7 +10,7 @@ use {
 };
 
 /// The quoting style to use when writing CSV data.
-#[deriving(Copy)]
+#[derive(Copy)]
 pub enum QuoteStyle {
     /// This puts quotes around every field. Always.
     Always,


### PR DESCRIPTION
Fixes `deriving` being renamed to `derive`, and partial fix for
associated types (still need to wait for certain traits to implement
associated types).