### PR TITLE
FullRange was renamed to RangeFull

### DIFF
--- a/src/bytestr.rs
+++ b/src/bytestr.rs
@@ -179,10 +179,10 @@ impl ops::Deref for ByteString {
     }
 }
 
-impl ops::Index<ops::FullRange> for ByteString {
+impl ops::Index<ops::RangeFull> for ByteString {
     type Output = [u8];
 
-    fn index<'a>(&'a self, _: &ops::FullRange) -> &'a [u8] {
+    fn index<'a>(&'a self, _: &ops::RangeFull) -> &'a [u8] {
         &**self
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -219,7 +219,7 @@ mod test;
 pub type CsvResult<T> = Result<T, Error>;
 
 /// An error produced by an operation on CSV data.
-#[derive(Clone, Show)]
+#[derive(Clone, Debug)]
 pub enum Error {
     /// An error reported by the type-based encoder.
     Encode(String),
@@ -244,7 +244,7 @@ impl Error {
 }
 
 /// A description of a CSV parse error.
-#[derive(Clone, Copy, Show)]
+#[derive(Clone, Copy, Debug)]
 pub struct ParseError {
     /// The line number of the parse error.
     pub line: u64,
@@ -262,7 +262,7 @@ pub struct ParseError {
 ///
 /// If and when a "strict" mode is added to this crate, this list of errors
 /// will expand.
-#[derive(Clone, Copy, Show)]
+#[derive(Clone, Copy, Debug)]
 pub enum ParseErrorKind {
     /// This error occurs when a record has a different number of fields
     /// than the first record parsed.

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -230,10 +230,10 @@ impl<R: io::Reader> Reader<R> {
     /// # extern crate csv;
     /// # fn main() {
     ///
-    /// #[derive(RustcDecodable, PartialEq, Show)]
+    /// #[derive(RustcDecodable, PartialEq, Debug)]
     /// struct MyUint(u32);
     ///
-    /// #[derive(RustcDecodable, PartialEq, Show)]
+    /// #[derive(RustcDecodable, PartialEq, Debug)]
     /// enum Number { Integer(i64), Float(f64) }
     ///
     /// #[derive(RustcDecodable)]
@@ -810,7 +810,7 @@ struct ParseMachine {
     double_quote: bool,
 }
 
-#[derive(Copy, Eq, PartialEq, Show)]
+#[derive(Copy, Eq, PartialEq, Debug)]
 enum ParseState {
     StartRecord,
     EndRecord,


### PR DESCRIPTION
[This](https://travis-ci.org/BurntSushi/rust-csv/builds/49010538) build failed since there were some changed in the nightly rust builds.  

`FullRange -> RangeFull` (produced an error)
`Show -> Debug` (produced a warning)