### PR TITLE
Make decoder work with newest nightly build.

### DIFF
--- a/examples/rational_numbers.rs
+++ b/examples/rational_numbers.rs
@@ -1,7 +1,7 @@
 //! This example shows how to write your own custom implementation of
 //! `Decodable` to parse rational numbers.
 
-#![feature(collections, core)]
+#![feature(core)]
 
 extern crate csv;
 extern crate regex;
@@ -23,22 +23,27 @@ impl Decodable for Rational {
         let field = try!(d.read_str());
         // This uses the `FromStr` impl below.
         match field.parse() {
-            Some(rat) => Ok(rat),
-            None => Err(d.error(&*format!(
+            Ok(rat) => Ok(rat),
+            Err(_) => Err(d.error(&*format!(
                 "Could not parse '{}' as a rational.", field))),
         }
     }
 }
 
 impl str::FromStr for Rational {
+    type Err = csv::Error;
+
     /// Parse a string into a Rational. Allow for the possibility of whitespace
     /// around `/`.
-    fn from_str(s: &str) -> Option<Rational> {
+    fn from_str(s: &str) -> Result<Rational, csv::Error> {
         let re = Regex::new(r"^([0-9]+)\s*/\s*([0-9]+)$").unwrap();
-        re.captures(s).map(|caps| Rational {
+        match re.captures(s).map(|caps| Rational {
             numerator: caps.at(1).unwrap().parse().unwrap(),
             denominator: caps.at(2).unwrap().parse().unwrap(),
-        })
+        }) {
+            Some(r) => Ok(r),
+            None => Err(csv::Error::Encode(format!("Failed to parse Rational {}", s))),
+        }
     }
 }
 

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -53,8 +53,8 @@ impl Decoded {
         let s = try!(self.pop_string());
         let s = s.trim();
         match FromStr::from_str(s) {
-            Some(t) => Ok(t),
-            None => self.err(format!("Failed converting '{}' from str.", s)),
+            Ok(t) => Ok(t),
+            Err(_) => self.err(format!("Failed converting '{}' from str.", s)),
         }
     }
 

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -239,7 +239,7 @@ impl<W: io::Writer> Writer<W> {
     /// Writes a record of results. If any of the results resolve to an error,
     /// then writing stops and that error is returned.
     #[doc(hidden)]
-    pub fn write_iter<'a, I, F>(&mut self, mut r: I) -> CsvResult<()>
+    pub fn write_iter<'a, I, F>(&mut self, r: I) -> CsvResult<()>
             where I: Iterator<Item=CsvResult<F>>, F: BorrowBytes {
         let delim = self.delimiter;
         let mut count = 0;


### PR DESCRIPTION
`FromStr::from_str` now returns `Result` not `Option`.

I'm not sure if we want to do something useful with the error wrapped in `Err`. I currently ignore it.