### PR TITLE
Serde support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,21 @@
 language: rust
+rust:
+  - "nightly"
+  - "beta"
+env:
+  - FEATURES="serde" TEST_FEATURES="serde-test"
+  - FEATURES="rustc-serialize" TEST_FEATURES="rustc-serialize"
 matrix:
-  include:
-    - rust: "nightly"
-      env: TEST_SUITE=suite_nightly
-    - rust: "beta"
-      env: TEST_SUITE=suite_beta
+  exclude:
+    - rust: beta
+      env: FEATURES="serde" TEST_FEATURES="serde-test"
 script:
-  - cargo build --verbose
-  - cargo test --verbose
-  - if [ "$TEST_SUITE" = "suite_nightly" ]; then
-      cargo bench --verbose;
+  - echo $TRAVIS_RUST_VERSION
+  - cargo build --verbose --no-default-features --features $FEATURES
+  - cargo test --verbose --no-default-features --features $TEST_FEATURES --lib --test tests
+  - if [[ $FEATURES == "rustc-serialize" ]]; then
+      cargo test --verbose --no-default-features --features $TEST_FEATURES --doc;
+    fi
+  - if [[ $TRAVIS_RUST_VERSION == "nightly" ]]; then
+      cargo bench --verbose --no-default-features --features $TEST_FEATURES;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ matrix:
     - rust: beta
       env: FEATURES="serde" TEST_FEATURES="serde-test"
 script:
-  - echo $TRAVIS_RUST_VERSION
   - cargo build --verbose --no-default-features --features $FEATURES
   - cargo test --verbose --no-default-features --features $TEST_FEATURES --lib --test tests
   - if [[ $FEATURES == "rustc-serialize" ]]; then

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,9 +26,12 @@ byteorder = "0.3"
 rustc-serialize = { version = "0.3", optional = true }
 serde = { version = "0.7.7", optional = true }
 
+# Only used for tests. Would like to put in dev-dependencies but unfortunately
+# won't even compile on beta branch
+serde_macros = { version = "0.7.7", optional = true }
+
 [dev-dependencies]
 regex = "0.1"
-serde_macros = "0.7.7"
 
 [profile.bench]
 opt-level = 3
@@ -40,3 +43,4 @@ lto = true
 
 [features]
 default = ["rustc-serialize"]
+serde-test = ["serde", "serde_macros"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ documentation = "http://burntsushi.net/rustdoc/csv/"
 homepage = "https://github.com/BurntSushi/rust-csv"
 repository = "https://github.com/BurntSushi/rust-csv"
 readme = "README.md"
-keywords = ["csv", "tsv", "comma", "parser", "delimited"]
+keywords = ["csv", "tsv", "comma", "parser", "delimited", "serde"]
 license = "Unlicense/MIT"
 
 [lib]
@@ -23,10 +23,12 @@ doc = false
 
 [dependencies]
 byteorder = "0.3"
-rustc-serialize = "0.3"
+rustc-serialize = { version = "0.3", optional = true }
+serde = { version = "0.7.7", optional = true }
 
 [dev-dependencies]
 regex = "0.1"
+serde_macros = "0.7.7"
 
 [profile.bench]
 opt-level = 3
@@ -35,3 +37,6 @@ lto = true  # this doesn't seem to work... why?
 [profile.release]
 opt-level = 3
 lto = true
+
+[features]
+default = ["rustc-serialize"]

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,7 +1,7 @@
 #![feature(test)]
 
-#![cfg_attr(feature = "serde", feature(custom_derive, plugin))]
-#![cfg_attr(feature = "serde", plugin(serde_macros))]
+#![cfg_attr(feature = "serde-test", feature(custom_derive, plugin))]
+#![cfg_attr(feature = "serde-test", plugin(serde_macros))]
 
 extern crate csv;
 

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,7 +1,13 @@
 #![feature(test)]
 
+#![cfg_attr(feature = "serde", feature(custom_derive, plugin))]
+#![cfg_attr(feature = "serde", plugin(serde_macros))]
+
 extern crate csv;
+
+#[cfg(feature = "rustc-serialize")]
 extern crate rustc_serialize;
+
 extern crate test;
 
 use std::fmt::{Debug, Display};
@@ -65,7 +71,8 @@ fn string_records(b: &mut Bencher) {
 }
 
 #[allow(dead_code)]
-#[derive(RustcDecodable)]
+#[cfg_attr(feature = "rustc-serialize", derive(RustcDecodable))]
+#[cfg_attr(feature = "serde", derive(Deserialize))]
 struct Play {
     gameid: String,
     qtr: i32,

--- a/examples/nfl_plays.rs
+++ b/examples/nfl_plays.rs
@@ -1,8 +1,13 @@
+#![cfg_attr(feature = "serde", feature(custom_derive, plugin))]
+#![cfg_attr(feature = "serde", plugin(serde_macros))]
+
 extern crate csv;
+#[cfg(feature = "rustc-serialize")]
 extern crate rustc_serialize;
 
 #[allow(dead_code)]
-#[derive(RustcDecodable)]
+#[cfg_attr(feature = "rustc-serialize", derive(RustcDecodable))]
+#[cfg_attr(feature = "serde", derive(Deserialize))]
 struct Play {
     gameid: String,
     qtr: u32,

--- a/examples/simple_missing.rs
+++ b/examples/simple_missing.rs
@@ -1,7 +1,12 @@
+#![cfg_attr(feature = "serde", feature(custom_derive, plugin))]
+#![cfg_attr(feature = "serde", plugin(serde_macros))]
+
 extern crate csv;
+#[cfg(feature = "rustc-serialize")]
 extern crate rustc_serialize;
 
-#[derive(RustcDecodable)]
+#[cfg_attr(feature = "rustc-serialize", derive(RustcDecodable))]
+#[cfg_attr(feature = "serde", derive(Deserialize))]
 struct Record {
     s1: String,
     s2: String,

--- a/examples/simple_struct.rs
+++ b/examples/simple_struct.rs
@@ -1,7 +1,12 @@
+#![cfg_attr(feature = "serde", feature(custom_derive, plugin))]
+#![cfg_attr(feature = "serde", plugin(serde_macros))]
+
 extern crate csv;
+#[cfg(feature = "rustc-serialize")]
 extern crate rustc_serialize;
 
-#[derive(RustcDecodable)]
+#[cfg_attr(feature = "rustc-serialize", derive(RustcDecodable))]
+#[cfg_attr(feature = "serde", derive(Deserialize))]
 struct Record {
     s1: String,
     s2: String,

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,0 +1,128 @@
+use std::str::FromStr;
+
+use {ByteString, Result, Error};
+
+/// A record to be decoded.
+///
+/// This is a "wrapper" type that allows the `Decoder` machinery from the
+/// `serialize` crate to decode a *single* CSV record into your custom types.
+///
+/// Generally, you should not need to use this type directly. Instead, you
+/// should prefer the `decode` or `decode_all` methods defined on `CsvReader`.
+pub struct Decoded {
+    stack: Vec<ByteString>,
+    popped: usize,
+}
+
+impl Decoded {
+    /// Creates a new decodable record from a record of byte strings.
+    pub fn new(mut bytes: Vec<ByteString>) -> Decoded {
+        bytes.reverse();
+        Decoded { stack: bytes, popped: 0 }
+    }
+}
+
+pub trait DecodedHelper {
+    fn len(&self) -> usize;
+    fn pop(&mut self) -> Result<ByteString>;
+    fn pop_string(&mut self) -> Result<String>;
+    fn pop_from_str<T: FromStr + Default>(&mut self) -> Result<T>;
+    fn push(&mut self, s: ByteString);
+    fn push_string(&mut self, s: String);
+    fn err<'a, T, S>(&self, msg: S) -> Result<T> where S: Into<String>;
+}
+
+impl DecodedHelper for Decoded {
+    fn len(&self) -> usize {
+        self.stack.len()
+    }
+
+    fn pop(&mut self) -> Result<ByteString> {
+        self.popped += 1;
+        match self.stack.pop() {
+            None => self.err(format!(
+                "Expected a record with length at least {}, \
+                 but got a record with length {}.",
+                self.popped, self.popped - 1)),
+            Some(bytes) => Ok(bytes),
+        }
+    }
+
+    fn pop_string(&mut self) -> Result<String> {
+        String::from_utf8(try!(self.pop())).map_err(|bytes| {
+            Error::Decode(
+                format!("Could not convert bytes '{:?}' to UTF-8.", bytes))
+        })
+    }
+
+    fn pop_from_str<T: FromStr + Default>(&mut self) -> Result<T> {
+        let s = try!(self.pop_string());
+        let s = s.trim();
+        match FromStr::from_str(s) {
+            Ok(t) => Ok(t),
+            Err(_) => self.err(format!("Failed converting '{}' from str.", s)),
+        }
+    }
+
+    fn push(&mut self, s: ByteString) {
+        self.stack.push(s);
+    }
+
+    fn push_string(&mut self, s: String) {
+        self.push(s.into_bytes());
+    }
+
+    fn err<'a, T, S>(&self, msg: S) -> Result<T> where S: Into<String> {
+        Err(Error::Decode(msg.into()))
+    }
+}
+
+
+/// A record to be encoded.
+///
+/// This is a "wrapper" type that allows the `Encoder` machinery from the
+/// `serialize` crate to encode a *single* CSV record from your custom types.
+///
+/// Generally, you should not need to use this type directly. Instead, you
+/// should prefer the `encode` or `encode_all` methods defined on `CsvWriter`.
+pub struct Encoded {
+    record: Vec<ByteString>,
+}
+
+impl Encoded {
+    /// Creates a new encodable record. The value returned can be passed to
+    /// `Encodable::encode`.
+    pub fn new() -> Encoded { Encoded { record: vec![] } }
+
+    /// Once a record has been encoded into this value, `unwrap` can be used
+    /// to access the raw CSV record.
+    pub fn unwrap(self) -> Vec<ByteString> { self.record }
+}
+
+pub trait EncodedHelper {
+    fn push_bytes<'a, S>(&mut self, s: S) -> Result<()> where S: Into<Vec<u8>>;
+    fn push_string<'a, S>(&mut self, s: S) -> Result<()> where S: Into<String>;
+    fn push_to_string<T: ToString>(&mut self, t: T) -> Result<()>;
+}
+
+impl EncodedHelper for Encoded {
+    fn push_bytes<'a, S>(&mut self, s: S) -> Result<()>
+            where S: Into<Vec<u8>> {
+        self.record.push(s.into());
+        Ok(())
+    }
+
+    fn push_string<'a, S>(&mut self, s: S) -> Result<()>
+            where S: Into<String> {
+        self.push_bytes(s.into().into_bytes())
+    }
+
+    fn push_to_string<T: ToString>(&mut self, t: T) -> Result<()> {
+        self.push_string(t.to_string())
+    }
+}
+
+pub fn float_to_string(v: f64) -> String {
+    let s: String = format!("{:.10}", v).trim_right_matches('0').into();
+    if s.ends_with('.') { s + "0" } else { s }
+}

--- a/src/rustc_serialize_impl/decoder.rs
+++ b/src/rustc_serialize_impl/decoder.rs
@@ -1,74 +1,8 @@
-use std::default::Default;
-use std::str::FromStr;
-
 use rustc_serialize as serialize;
 
-use {ByteString, Result, Error};
+use common::{Decoded, DecodedHelper};
 
-/// A record to be decoded.
-///
-/// This is a "wrapper" type that allows the `Decoder` machinery from the
-/// `serialize` crate to decode a *single* CSV record into your custom types.
-///
-/// Generally, you should not need to use this type directly. Instead, you
-/// should prefer the `decode` or `decode_all` methods defined on `CsvReader`.
-pub struct Decoded {
-    stack: Vec<ByteString>,
-    popped: usize,
-}
-
-impl Decoded {
-    /// Creates a new decodable record from a record of byte strings.
-    pub fn new(mut bytes: Vec<ByteString>) -> Decoded {
-        bytes.reverse();
-        Decoded { stack: bytes, popped: 0 }
-    }
-
-    fn len(&self) -> usize {
-        self.stack.len()
-    }
-}
-
-impl Decoded {
-    fn pop(&mut self) -> Result<ByteString> {
-        self.popped += 1;
-        match self.stack.pop() {
-            None => self.err(format!(
-                "Expected a record with length at least {}, \
-                 but got a record with length {}.",
-                self.popped, self.popped - 1)),
-            Some(bytes) => Ok(bytes),
-        }
-    }
-
-    fn pop_string(&mut self) -> Result<String> {
-        String::from_utf8(try!(self.pop())).map_err(|bytes| {
-            Error::Decode(
-                format!("Could not convert bytes '{:?}' to UTF-8.", bytes))
-        })
-    }
-
-    fn pop_from_str<T: FromStr + Default>(&mut self) -> Result<T> {
-        let s = try!(self.pop_string());
-        let s = s.trim();
-        match FromStr::from_str(s) {
-            Ok(t) => Ok(t),
-            Err(_) => self.err(format!("Failed converting '{}' from str.", s)),
-        }
-    }
-
-    fn push(&mut self, s: ByteString) {
-        self.stack.push(s);
-    }
-
-    fn push_string(&mut self, s: String) {
-        self.push(s.into_bytes());
-    }
-
-    fn err<'a, T, S>(&self, msg: S) -> Result<T> where S: Into<String> {
-        Err(Error::Decode(msg.into()))
-    }
-}
+use {Result, Error};
 
 impl serialize::Decoder for Decoded {
     type Error = Error;

--- a/src/rustc_serialize_impl/encoder.rs
+++ b/src/rustc_serialize_impl/encoder.rs
@@ -1,42 +1,7 @@
 use rustc_serialize as serialize;
+use {Result, Error};
 
-use {ByteString, Result, Error};
-
-/// A record to be encoded.
-///
-/// This is a "wrapper" type that allows the `Encoder` machinery from the
-/// `serialize` crate to encode a *single* CSV record from your custom types.
-///
-/// Generally, you should not need to use this type directly. Instead, you
-/// should prefer the `encode` or `encode_all` methods defined on `CsvWriter`.
-pub struct Encoded {
-    record: Vec<ByteString>,
-}
-
-impl Encoded {
-    /// Creates a new encodable record. The value returned can be passed to
-    /// `Encodable::encode`.
-    pub fn new() -> Encoded { Encoded { record: vec![] } }
-
-    /// Once a record has been encoded into this value, `unwrap` can be used
-    /// to access the raw CSV record.
-    pub fn unwrap(self) -> Vec<ByteString> { self.record }
-
-    fn push_bytes<'a, S>(&mut self, s: S) -> Result<()>
-            where S: Into<Vec<u8>> {
-        self.record.push(s.into());
-        Ok(())
-    }
-
-    fn push_string<'a, S>(&mut self, s: S) -> Result<()>
-            where S: Into<String> {
-        self.push_bytes(s.into().into_bytes())
-    }
-
-    fn push_to_string<T: ToString>(&mut self, t: T) -> Result<()> {
-        self.push_string(t.to_string())
-    }
-}
+use common::{Encoded, EncodedHelper, float_to_string};
 
 impl serialize::Encoder for Encoded {
     type Error = Error;
@@ -159,9 +124,4 @@ impl serialize::Encoder for Encoded {
                        where F: FnOnce(&mut Encoded) -> Result<()> {
         unimplemented!()
     }
-}
-
-fn float_to_string(v: f64) -> String {
-    let s: String = format!("{:.10}", v).trim_right_matches('0').into();
-    if s.ends_with('.') { s + "0" } else { s }
 }

--- a/src/rustc_serialize_impl/mod.rs
+++ b/src/rustc_serialize_impl/mod.rs
@@ -1,0 +1,2 @@
+mod encoder;
+mod decoder;

--- a/src/serde_impl/de.rs
+++ b/src/serde_impl/de.rs
@@ -1,0 +1,168 @@
+use {Result, Error};
+
+use common::{Decoded, DecodedHelper};
+
+use serde::de::{self, Deserializer, Deserialize, Visitor};
+
+macro_rules! simple_deserialize {
+    ($name:ident, $visitfn:ident) => {
+        #[inline]
+        fn $name<V: Visitor>(&mut self, mut visitor: V) -> Result<V::Value> {
+            let v = try!(self.pop_from_str());
+            visitor.$visitfn(v)
+        }
+    }
+}
+
+impl Deserializer for Decoded {
+    type Error = Error;
+
+    #[inline]
+    fn deserialize<V: Visitor>(&mut self, mut _visitor: V) -> Result<V::Value> {
+        unimplemented!();
+    }
+
+    simple_deserialize!(deserialize_i8,  visit_i8);
+    simple_deserialize!(deserialize_i16, visit_i16);
+    simple_deserialize!(deserialize_i32, visit_i32);
+    simple_deserialize!(deserialize_i64, visit_i64);
+    simple_deserialize!(deserialize_isize, visit_isize);
+
+    simple_deserialize!(deserialize_u8,  visit_u8);
+    simple_deserialize!(deserialize_u16, visit_u16);
+    simple_deserialize!(deserialize_u32, visit_u32);
+    simple_deserialize!(deserialize_u64, visit_u64);
+    simple_deserialize!(deserialize_usize, visit_usize);
+
+    simple_deserialize!(deserialize_f32, visit_f32);
+    simple_deserialize!(deserialize_f64, visit_f64);
+
+    #[inline]
+    fn deserialize_bool<V: Visitor>(&mut self, mut visitor: V) -> Result<V::Value> {
+        let s = try!(self.pop_string());
+        let s = s.trim();
+        match s {
+            "true" => visitor.visit_bool(true),
+            "false" => visitor.visit_bool(false),
+            _ => self.err(format!("Expected 'true' or 'false' but found '{}'.", s))
+        }
+    }
+
+    #[inline]
+    fn deserialize_str<V: Visitor>(&mut self, mut visitor: V) -> Result<V::Value> {
+        let v = try!(self.pop_string());
+        visitor.visit_str(&v)
+    }
+
+    #[inline]
+    fn deserialize_char<V: Visitor>(&mut self, mut visitor: V) -> Result<V::Value> {
+        let s = try!(self.pop_string());
+        let chars: Vec<char> = s.chars().collect();
+        if chars.len() != 1 {
+            return self.err(format!("Expected single character but got '{}'.", s))
+        }
+        visitor.visit_char(chars[0])
+    }
+
+    #[inline]
+    fn deserialize_option<V: Visitor>(&mut self, mut visitor: V) -> Result<V::Value> {
+        let val = try!(self.pop_string());
+        if val.is_empty() {
+            visitor.visit_none()
+        } else {
+            self.push_string(val);
+            match visitor.visit_some(self) {
+                Ok(v) => Ok(v),
+                Err(_) => visitor.visit_none()
+            }
+        }
+    }
+
+    #[inline]
+    fn deserialize_tuple<V: Visitor>(&mut self, _len: usize,
+                            mut visitor: V) -> Result<V::Value> {
+        struct TupleVisitor<'a>(&'a mut Decoded);
+        impl<'a> de::SeqVisitor for TupleVisitor<'a> {
+            type Error = Error;
+
+            fn visit<T>(&mut self) -> Result<Option<T>> where T: Deserialize {
+                Deserialize::deserialize(self.0).map(|v| Some(v))
+            }
+
+            fn end(&mut self) -> Result<()> {
+                Ok(())
+            }
+        }
+        visitor.visit_seq(TupleVisitor(self))
+    }
+
+    #[inline]
+    fn deserialize_seq<V: Visitor>(&mut self, mut visitor: V) -> Result<V::Value> {
+        struct SeqVisitor<'a>(&'a mut Decoded);
+        impl<'a> de::SeqVisitor for SeqVisitor<'a> {
+            type Error = Error;
+
+            fn visit<T>(&mut self) -> Result<Option<T>> where T: Deserialize {
+                // TODO is this the correct way to handle vecs?
+                // i.e. keep trying to fetch more until failing with 'end of bytevec'
+                // error, then catch Err and return OK
+                match Deserialize::deserialize(self.0) {
+                    Ok(v) => Ok(Some(v)),
+                    Err(_) => Ok(None)
+                }
+            }
+
+            fn end(&mut self) -> Result<()> {
+                Ok(())
+            }
+        }
+        visitor.visit_seq(SeqVisitor(self))
+    }
+
+    #[inline]
+    fn deserialize_enum<V>(&mut self, _enum: &'static str,
+                           variants: &'static [&'static str],
+                           mut visitor: V) -> Result<V::Value>
+        where V: de::EnumVisitor
+    {
+        struct VariantVisitor<'a>(usize, &'a mut Decoded);
+
+        impl<'a> de::VariantVisitor for VariantVisitor<'a> {
+            type Error = Error;
+
+            #[inline]
+            fn visit_variant<D>(&mut self) -> Result<D> where D: Deserialize {
+                use serde::de::value::ValueDeserializer;
+                let mut deserializer = self.0.into_deserializer();
+                Deserialize::deserialize(&mut deserializer)
+            }
+
+            #[inline]
+            fn visit_newtype<D>(&mut self) -> Result<D> where D: Deserialize {
+                Deserialize::deserialize(self.1)
+            }
+        }
+
+        let cur = try!(self.pop_string());
+        self.push_string(cur.clone());
+        // try each varient in turn
+        for i in 0..variants.len() {
+            match visitor.visit(VariantVisitor(i, self)) {
+                Ok(v) => return Ok(v),
+                Err(_) => { self.push_string(cur.clone()); }
+            }
+        }
+        // No variant matched, bail out
+        let cur = try!(self.pop_string());
+        self.err(format!("Failed to decode variant '{}'", cur))
+    }
+
+    #[inline]
+    fn deserialize_struct<V>(&mut self, _name: &'static str,
+                             fields: &'static [&'static str],
+                             visitor: V) -> Result<V::Value>
+        where V: Visitor
+    {
+        self.deserialize_tuple(fields.len(), visitor)
+    }
+}

--- a/src/serde_impl/mod.rs
+++ b/src/serde_impl/mod.rs
@@ -1,0 +1,2 @@
+mod de;
+mod ser;

--- a/src/serde_impl/ser.rs
+++ b/src/serde_impl/ser.rs
@@ -1,0 +1,94 @@
+use serde::ser;
+
+use {Result, Error};
+
+use common::{Encoded, EncodedHelper, float_to_string};
+
+macro_rules! write_display {
+    ($name:ident, $t:ty) => {
+        #[inline]
+        fn $name(&mut self, value: $t) -> Result<()> {
+            self.push_to_string(format!("{}", value))
+        }
+    }
+}
+
+impl ser::Serializer for Encoded {
+    type Error = Error;
+
+    write_display!(serialize_bool, bool);
+
+    write_display!(serialize_i8, i8);
+    write_display!(serialize_i16, i16);
+    write_display!(serialize_i32, i32);
+    write_display!(serialize_i64, i64);
+    write_display!(serialize_isize, isize);
+
+    write_display!(serialize_u8, u8);
+    write_display!(serialize_u16, u16);
+    write_display!(serialize_u32, u32);
+    write_display!(serialize_u64, u64);
+    write_display!(serialize_usize, usize);
+
+    write_display!(serialize_str, &str);
+    write_display!(serialize_char, char);
+
+    #[inline]
+    fn serialize_f32(&mut self, value: f32) -> Result<()> {
+        self.push_to_string(float_to_string(value as f64))
+    }
+
+    #[inline]
+    fn serialize_f64(&mut self, value: f64) -> Result<()> {
+        self.push_to_string(float_to_string(value))
+    }
+
+    #[inline]
+    fn serialize_none(&mut self) -> Result<()> {
+        self.push_bytes::<&[u8]>(&[])
+    }
+
+    #[inline]
+    fn serialize_some<V>(&mut self, value: V) -> Result<()>
+        where V: ser::Serialize
+    {
+        value.serialize(self)
+    }
+
+    #[inline]
+    fn serialize_unit(&mut self) -> Result<()> {
+        unimplemented!()
+    }
+
+    #[inline]
+    fn serialize_seq<V>(&mut self, mut visitor: V) -> Result<()>
+        where V: ser::SeqVisitor,
+    {
+        while let Some(()) = try!(visitor.visit(self)) {};
+        Ok(())
+    }
+
+    #[inline]
+    fn serialize_seq_elt<T>(&mut self, value: T) -> Result<()>
+        where T: ser::Serialize,
+    {
+        value.serialize(self)
+    }
+
+    #[inline]
+    fn serialize_map<V>(&mut self, mut visitor: V) -> Result<()>
+        where V: ser::MapVisitor,
+    {
+        while let Some(()) = try!(visitor.visit(self)) {};
+        Ok(())
+    }
+
+    #[inline]
+    fn serialize_map_elt<K, V>(&mut self, _key: K, value: V) -> Result<()>
+        where K: ser::Serialize,
+              V: ser::Serialize,
+    {
+        value.serialize(self)
+    }
+
+}


### PR DESCRIPTION
This PR adds `serde` support to rust-csv. For now it is best considered experimental. It is strictly opt-in and should not affect the API apart from changing the traits bounds on Reader::decode (Decodable -> Deserialize) and Writer::encode (Encodable -> Serialize).

It is a fairly major refactor so please review and comment.
