### PR TITLE
Use `extend_from_slice` instead of iterator `extend`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ doc = false
 [dependencies]
 byteorder = "0.5"
 rustc-serialize = "0.3"
+memchr = "0.1.11"
 
 [dev-dependencies]
 regex = "0.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,6 +183,7 @@
 #![deny(missing_docs)]
 
 extern crate byteorder;
+extern crate memchr;
 extern crate rustc_serialize;
 
 use std::error::Error as StdError;

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -3,6 +3,7 @@ use std::io::{self, Write};
 use std::path::Path;
 use std::str;
 
+use memchr::memchr;
 use rustc_serialize::Encodable;
 
 use {
@@ -443,7 +444,7 @@ impl<W: io::Write> Writer<W> {
 
         buf.push(self.quote);
         loop {
-            match s.iter().position(|&v| v == self.quote) {
+            match memchr(self.quote, s) {
                 None => {
                     buf.extend_from_slice(s);
                     break

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -445,11 +445,11 @@ impl<W: io::Write> Writer<W> {
         loop {
             match s.iter().position(|&v| v == self.quote) {
                 None => {
-                    buf.extend(s.iter().map(|&x|x));
+                    buf.extend_from_slice(s);
                     break
                 }
                 Some(next_quote) => {
-                    buf.extend(s[..next_quote].iter().map(|&x|x));
+                    buf.extend_from_slice(&s[..next_quote]);
                     if self.double_quote {
                         buf.push(self.quote);
                         buf.push(self.quote);


### PR DESCRIPTION
Extending a Vec using `extend_from_slice` is much faster than extending from an iterator. This reduces the time needed for quoting a string by 40-65% (40% on 50-char strings, 65% on 1000-char strings) if the char contains no escape characters. Also, I think it looks nicer 😃