### PR TITLE
Multiline Feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,9 @@ test = false
 bench = false
 doc = false
 
+[features]
+multiline = []
+
 [dependencies]
 byteorder = "0.5"
 rustc-serialize = "0.3"

--- a/README.md
+++ b/README.md
@@ -80,6 +80,30 @@ get plain access to records as vectors of strings. There are examples with more
 details in the documentation.
 
 
+### Features
+
+The crate has additional features which are disabled by default but they can
+be enabled using [\[features\] section](http://doc.crates.io/manifest.html#the-features-section).
+
+The only feature the crate supports now is `multiline`.
+
+
+#### Multiline
+
+The `multiline` feature allows to change the parsing behavior. By default the parser allows multiline records when quoted field my have one more or EOLs (see the example below).
+
+```csv
+Field1,Field2,"Multiline
+field",Field4,Field5
+```
+
+The feature introduces a new parsing boolean option `Reader::multiline` which by default is `true`, which is the default behavior. When the option is set to `false` the parser does not allow multiline records and when it encounters a record like in the example the further action depends on `Reader::flexible` option.
+
+- If `flexible` is `true` then the parser returns the record where the number of fields may differ from the number of fields in the first record.
+- If `flexible` is `false` then the parser returns error `ParseError::UnclosedQuotedField` enclosed in `LocatableError`.
+
+_Please notice enabling that feature may slightly reduce the parser performance._
+
 ### Installation
 
 This crate works with Cargo and is on

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -268,6 +268,10 @@ pub enum ParseError {
     ///
     /// TODO: Include the real Utf8Error, but it is not stabilized yet.
     InvalidUtf8,
+    /// A record was found where a quoted field has no the closing quote.
+    /// Effective only if the feature `multiline` is enabled.
+    #[cfg(feature = "multiline")]
+    UnclosedQuotedField,
 }
 
 impl fmt::Display for Error {
@@ -297,6 +301,10 @@ impl fmt::Display for ParseError {
                            with length {}.", expected, got),
             ParseError::InvalidUtf8 =>
                 write!(f, "Invalid UTF8 encoding."),
+            // This error is available only if the multiline feature is enabled.
+            #[cfg(feature = "multiline")]
+            ParseError::UnclosedQuotedField =>
+                write!(f, "Record has unclosed quoted field."),
         }
     }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -461,3 +461,53 @@ fn scratch() {
         let _ = writeln!(&mut io::stderr(), "{:?}", row);
     }
 }
+
+#[test]
+#[cfg(feature = "multiline")]
+fn multiline_and_flexible() {
+    let mut rdr = Reader::from_string("h1,h2\n1,\"unclosed\n2,no_quotes").has_headers(false).flexible(true).multiline(true);
+    let mut record_count = 0;
+    for row in rdr.records() {
+        let _ = writeln!(&mut io::stderr(), "{:?}", row.unwrap());
+        record_count = record_count + 1;
+    }
+    assert_eq!(record_count, 2);
+}
+
+#[test]
+#[should_panic]
+#[cfg(feature = "multiline")]
+fn multiline_and_not_flexible() {
+    let mut rdr = Reader::from_string("h1,h2\n1,\"unclosed\n2,no_quotes").has_headers(false).flexible(false).multiline(true);
+    let mut record_count = 0;
+    for row in rdr.records() {
+        let _ = writeln!(&mut io::stderr(), "{:?}", row.unwrap());
+        record_count = record_count + 1;
+    }
+    assert_eq!(record_count, 3);
+}
+
+#[test]
+#[cfg(feature = "multiline")]
+fn not_multiline_and_flexible() {
+    let mut rdr = Reader::from_string("h1,h2\n1,\"unclosed\n2,no_quotes").has_headers(false).flexible(true).multiline(false);
+    let mut record_count = 0;
+    for row in rdr.records() {
+        let _ = writeln!(&mut io::stderr(), "{:?}", row.unwrap());
+        record_count = record_count + 1;
+    }
+    assert_eq!(record_count, 3);
+}
+
+#[test]
+#[should_panic]
+#[cfg(feature = "multiline")]
+fn not_multiline_and_not_flexible() {
+    let mut rdr = Reader::from_string("h1,h2\n1,\"unclosed\n2,no_quotes").has_headers(false).flexible(false).multiline(false);
+    let mut record_count = 0;
+    for row in rdr.records() {
+        let _ = writeln!(&mut io::stderr(), "{:?}", row.unwrap());
+        record_count = record_count + 1;
+    }
+    assert_eq!(record_count, 3);
+}


### PR DESCRIPTION
Hello @BurntSushi,

I implement the request #54 as a crate feature. So by default the feature is disabled and the crate works without any change and when the feature the behavoir of `Reader` can be changed with `multiline` option. Enabling the feature may slighly reduce crate performance.

In short terms the behavior of `Reader` is:

- `multiline`=`true` - No changes.
- `multiline`=`false` - Depends on `flexible` option:
  * `flexible`=`true` - Return record where the number of fields may differ from the first record.
  * `flexible`=`false` - Return error `ParseError::UnclosedQuotedField`.