### PR TITLE
Don't break on EndOfRecord

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ fn main() {
     loop {
         match rdr.next_bytes() {
             NextField::EndOfCsv => break,
-            NextField::EndOfRecord => { count += 1; break; }
+            NextField::EndOfRecord => { count += 1; }
             NextField::Data(_) => {}
             NextField::Error(err) => panic!(err),
         }


### PR DESCRIPTION
Otherwise it will hit `break;` on the first occurrence of `EndOfRecord`, which will always result with a max count of 1.