### PR TITLE
optimizations for CSV writing

### DIFF
--- a/csv-core/src/lib.rs
+++ b/csv-core/src/lib.rs
@@ -104,11 +104,89 @@ extern crate arrayvec;
 extern crate memchr;
 
 pub use reader::{
-    Reader, ReaderBuilder, Terminator,
+    Reader, ReaderBuilder,
     ReadFieldResult, ReadFieldNoCopyResult,
     ReadRecordResult, ReadRecordNoCopyResult,
 };
-pub use writer::{Writer, WriterBuilder, WriteResult, QuoteStyle};
+pub use writer::{Writer, WriterBuilder, WriteResult};
 
 mod reader;
 mod writer;
+
+/// A record terminator.
+///
+/// Use this to specify the record terminator while parsing CSV. The default is
+/// CRLF, which treats `\r`, `\n` or `\r\n` as a single record terminator.
+#[derive(Clone, Copy, Debug)]
+pub enum Terminator {
+    /// Parses `\r`, `\n` or `\r\n` as a single record terminator.
+    CRLF,
+    /// Parses the byte given as a record terminator.
+    Any(u8),
+    /// Hints that destructuring should not be exhaustive.
+    ///
+    /// This enum may grow additional variants, so this makes sure clients
+    /// don't count on exhaustive matching. (Otherwise, adding a new variant
+    /// could break existing code.)
+    #[doc(hidden)]
+    __Nonexhaustive,
+}
+
+impl Terminator {
+    /// Checks whether the terminator is set to CRLF.
+    fn is_crlf(&self) -> bool {
+        match *self {
+            Terminator::CRLF => true,
+            Terminator::Any(_) => false,
+            _ => unreachable!(),
+        }
+    }
+
+    fn equals(&self, other: u8) -> bool {
+        match *self {
+            Terminator::CRLF => other == b'\r' || other == b'\n',
+            Terminator::Any(b) => other == b,
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl Default for Terminator {
+    fn default() -> Terminator {
+        Terminator::CRLF
+    }
+}
+
+/// The quoting style to use when writing CSV data.
+#[derive(Clone, Copy, Debug)]
+pub enum QuoteStyle {
+    /// This puts quotes around every field. Always.
+    Always,
+    /// This puts quotes around fields only when necessary.
+    ///
+    /// They are necessary when fields contain a quote, delimiter or record
+    /// terminator. Quotes are also necessary when writing an empty record
+    /// (which is indistinguishable from a record with one empty field).
+    ///
+    /// This is the default.
+    Necessary,
+    /// This puts quotes around all fields that are non-numeric. Namely, when
+    /// writing a field that does not parse as a valid float or integer, then
+    /// quotes will be used even if they aren't strictly necessary.
+    NonNumeric,
+    /// This *never* writes quotes, even if it would produce invalid CSV data.
+    Never,
+    /// Hints that destructuring should not be exhaustive.
+    ///
+    /// This enum may grow additional variants, so this makes sure clients
+    /// don't count on exhaustive matching. (Otherwise, adding a new variant
+    /// could break existing code.)
+    #[doc(hidden)]
+    __Nonexhaustive,
+}
+
+impl Default for QuoteStyle {
+    fn default() -> QuoteStyle {
+        QuoteStyle::Necessary
+    }
+}

--- a/csv-core/src/lib.rs
+++ b/csv-core/src/lib.rs
@@ -108,7 +108,7 @@ pub use reader::{
     ReadFieldResult, ReadFieldNoCopyResult,
     ReadRecordResult, ReadRecordNoCopyResult,
 };
-pub use writer::{Writer, WriterBuilder, WriteResult};
+pub use writer::{Writer, WriterBuilder, WriteResult, is_non_numeric, quote};
 
 mod reader;
 mod writer;

--- a/csv-core/src/writer.rs
+++ b/csv-core/src/writer.rs
@@ -432,6 +432,43 @@ impl Writer {
         }
     }
 
+    /// Return the delimiter used for this writer.
+    #[inline]
+    pub fn get_delimiter(&self) -> u8 {
+        self.delimiter
+    }
+
+    /// Return the terminator used for this writer.
+    #[inline]
+    pub fn get_terminator(&self) -> Terminator {
+        self.term
+    }
+
+    /// Return the quoting style used for this writer.
+    #[inline]
+    pub fn get_quote_style(&self) -> QuoteStyle {
+        self.style
+    }
+
+    /// Return the quote character used for this writer.
+    #[inline]
+    pub fn get_quote(&self) -> u8 {
+        self.quote
+    }
+
+    /// Return the escape character used for this writer.
+    #[inline]
+    pub fn get_escape(&self) -> u8 {
+        self.escape
+    }
+
+    /// Return whether this writer doubles quotes or not. When the writer
+    /// does not double quotes, it will escape them using the escape character.
+    #[inline]
+    pub fn get_double_quote(&self) -> bool {
+        self.double_quote
+    }
+
     fn write(&self, data: &[u8], output: &mut [u8]) -> (WriteResult, usize) {
         if data.len() > output.len() {
             (WriteResult::OutputFull, 0)

--- a/src/deserializer.rs
+++ b/src/deserializer.rs
@@ -12,7 +12,7 @@ use serde::de::{
 use serde::de::value::BorrowedBytesDeserializer;
 
 use byte_record::{ByteRecord, ByteRecordIter};
-use error::Error;
+use error::{Error, ErrorKind, new_error};
 use string_record::{StringRecord, StringRecordIter};
 
 use self::DeserializeErrorKind as DEK;
@@ -27,10 +27,10 @@ pub fn deserialize_string_record<'de, D: Deserialize<'de>>(
         field: 0,
     });
     D::deserialize(&mut deser).map_err(|err| {
-        Error::Deserialize {
+        new_error(ErrorKind::Deserialize {
             pos: record.position().map(Clone::clone),
             err: err,
-        }
+        })
     })
 }
 
@@ -44,10 +44,10 @@ pub fn deserialize_byte_record<'de, D: Deserialize<'de>>(
         field: 0,
     });
     D::deserialize(&mut deser).map_err(|err| {
-        Error::Deserialize {
+        new_error(ErrorKind::Deserialize {
             pos: record.position().map(Clone::clone),
             err: err,
-        }
+        })
     })
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,6 +7,12 @@ use std::str;
 use byte_record::{ByteRecord, Position};
 use deserializer::DeserializeError;
 
+/// A crate private constructor for `Error`.
+pub fn new_error(kind: ErrorKind) -> Error {
+    // TODO(burntsushi): Use `pub(crate)` when it stabilizes.
+    Error(Box::new(kind))
+}
+
 /// A type alias for `Result<T, csv::Error>`.
 pub type Result<T> = result::Result<T, Error>;
 
@@ -19,7 +25,34 @@ pub type Result<T> = result::Result<T, Error>;
 /// `flexible` option enabled and one is reading records as raw byte strings,
 /// then no error can occur.
 #[derive(Debug)]
-pub enum Error {
+pub struct Error(Box<ErrorKind>);
+
+impl Error {
+    /// Return the specific type of this error.
+    pub fn kind(&self) -> &ErrorKind {
+        &self.0
+    }
+
+    /// Unwrap this error into its underlying type.
+    pub fn into_kind(self) -> ErrorKind {
+        *self.0
+    }
+
+    /// Returns true if this is an I/O error.
+    ///
+    /// If this is true, the underlying `ErrorKind` is guaranteed to be
+    /// `ErrorKind::Io`.
+    pub fn is_io_error(&self) -> bool {
+        match *self.0 {
+            ErrorKind::Io(_) => true,
+            _ => false,
+        }
+    }
+}
+
+/// The specific type of an error.
+#[derive(Debug)]
+pub enum ErrorKind {
     /// An I/O error that occurred while reading CSV data.
     Io(io::Error),
     /// A UTF-8 decoding error that occured while reading CSV data into Rust
@@ -59,11 +92,18 @@ pub enum Error {
         /// The deserialization error.
         err: DeserializeError,
     },
+    /// Hints that destructuring should not be exhaustive.
+    ///
+    /// This enum may grow additional variants, so this makes sure clients
+    /// don't count on exhaustive matching. (Otherwise, adding a new variant
+    /// could break existing code.)
+    #[doc(hidden)]
+    __Nonexhaustive,
 }
 
 impl From<io::Error> for Error {
     fn from(err: io::Error) -> Error {
-        Error::Io(err)
+        new_error(ErrorKind::Io(err))
     }
 }
 
@@ -75,50 +115,52 @@ impl From<Error> for io::Error {
 
 impl StdError for Error {
     fn description(&self) -> &str {
-        match *self {
-            Error::Io(ref err) => err.description(),
-            Error::Utf8 { ref err, .. } => err.description(),
-            Error::UnequalLengths{..} => "record of different length found",
-            Error::Seek => "headers unavailable on seeked CSV reader",
-            Error::Serialize(ref err) => err,
-            Error::Deserialize { ref err, .. } => err.description(),
+        match *self.0 {
+            ErrorKind::Io(ref err) => err.description(),
+            ErrorKind::Utf8 { ref err, .. } => err.description(),
+            ErrorKind::UnequalLengths{..} => "record of different length found",
+            ErrorKind::Seek => "headers unavailable on seeked CSV reader",
+            ErrorKind::Serialize(ref err) => err,
+            ErrorKind::Deserialize { ref err, .. } => err.description(),
+            _ => unreachable!(),
         }
     }
 
     fn cause(&self) -> Option<&StdError> {
-        match *self {
-            Error::Io(ref err) => Some(err),
-            Error::Utf8 { ref err, .. } => Some(err),
-            Error::UnequalLengths{..} => None,
-            Error::Seek => None,
-            Error::Serialize(_) => None,
-            Error::Deserialize { ref err, .. } => Some(err),
+        match *self.0 {
+            ErrorKind::Io(ref err) => Some(err),
+            ErrorKind::Utf8 { ref err, .. } => Some(err),
+            ErrorKind::UnequalLengths{..} => None,
+            ErrorKind::Seek => None,
+            ErrorKind::Serialize(_) => None,
+            ErrorKind::Deserialize { ref err, .. } => Some(err),
+            _ => unreachable!(),
         }
     }
 }
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            Error::Io(ref err) => err.fmt(f),
-            Error::Utf8 { pos: None, ref err } => {
+        match *self.0 {
+            ErrorKind::Io(ref err) => err.fmt(f),
+            ErrorKind::Utf8 { pos: None, ref err } => {
                 write!(f, "CSV parse error: field {}: {}", err.field(), err)
             }
-            Error::Utf8 { pos: Some(ref pos), ref err } => {
+            ErrorKind::Utf8 { pos: Some(ref pos), ref err } => {
                 write!(
                     f,
                     "CSV parse error: record {} \
                      (line {}, field: {}, byte: {}): {}",
                     pos.record(), pos.line(), err.field(), pos.byte(), err)
             }
-            Error::UnequalLengths { pos: None, expected_len, len } => {
+            ErrorKind::UnequalLengths { pos: None, expected_len, len } => {
                 write!(
                     f, "CSV error: \
                         found record with {} fields, but the previous record \
                         has {} fields",
                     len, expected_len)
             }
-            Error::UnequalLengths {
+            ErrorKind::UnequalLengths {
                 pos: Some(ref pos), expected_len, len
             } => {
                 write!(
@@ -127,24 +169,25 @@ impl fmt::Display for Error {
                         has {} fields",
                     pos.record(), pos.line(), pos.byte(), len, expected_len)
             }
-            Error::Seek => {
+            ErrorKind::Seek => {
                 write!(f, "CSV error: cannot access headers of CSV data \
                            when the parser was seeked before the first record \
                            could be read")
             }
-            Error::Serialize(ref err) => {
+            ErrorKind::Serialize(ref err) => {
                 write!(f, "CSV write error: {}", err)
             }
-            Error::Deserialize { pos: None, ref err } => {
+            ErrorKind::Deserialize { pos: None, ref err } => {
                 write!(f, "CSV deserialize error: {}", err)
             }
-            Error::Deserialize { pos: Some(ref pos), ref err } => {
+            ErrorKind::Deserialize { pos: Some(ref pos), ref err } => {
                 write!(
                     f,
                     "CSV deserialize error: record {} \
                      (line: {}, byte: {}): {}",
                     pos.record(), pos.line(), pos.byte(), err)
             }
+            _ => unreachable!(),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -182,7 +182,9 @@ use serde::{Deserialize, Deserializer};
 
 pub use byte_record::{ByteRecord, ByteRecordIter, Position};
 pub use deserializer::{DeserializeError, DeserializeErrorKind};
-pub use error::{Error, FromUtf8Error, IntoInnerError, Result, Utf8Error};
+pub use error::{
+    Error, ErrorKind, FromUtf8Error, IntoInnerError, Result, Utf8Error,
+};
 pub use reader::{
     Reader, ReaderBuilder,
     DeserializeRecordsIntoIter, DeserializeRecordsIter,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -178,7 +178,6 @@ extern crate serde_derive;
 
 use std::result;
 
-pub use csv_core::{QuoteStyle, Terminator};
 use serde::{Deserialize, Deserializer};
 
 pub use byte_record::{ByteRecord, ByteRecordIter, Position};
@@ -202,6 +201,88 @@ mod serializer;
 mod string_record;
 pub mod tutorial;
 mod writer;
+
+/// The quoting style to use when writing CSV data.
+#[derive(Clone, Copy, Debug)]
+pub enum QuoteStyle {
+    /// This puts quotes around every field. Always.
+    Always,
+    /// This puts quotes around fields only when necessary.
+    ///
+    /// They are necessary when fields contain a quote, delimiter or record
+    /// terminator. Quotes are also necessary when writing an empty record
+    /// (which is indistinguishable from a record with one empty field).
+    ///
+    /// This is the default.
+    Necessary,
+    /// This puts quotes around all fields that are non-numeric. Namely, when
+    /// writing a field that does not parse as a valid float or integer, then
+    /// quotes will be used even if they aren't strictly necessary.
+    NonNumeric,
+    /// This *never* writes quotes, even if it would produce invalid CSV data.
+    Never,
+    /// Hints that destructuring should not be exhaustive.
+    ///
+    /// This enum may grow additional variants, so this makes sure clients
+    /// don't count on exhaustive matching. (Otherwise, adding a new variant
+    /// could break existing code.)
+    #[doc(hidden)]
+    __Nonexhaustive,
+}
+
+impl QuoteStyle {
+    fn to_core(self) -> csv_core::QuoteStyle {
+        match self {
+            QuoteStyle::Always => csv_core::QuoteStyle::Always,
+            QuoteStyle::Necessary => csv_core::QuoteStyle::Necessary,
+            QuoteStyle::NonNumeric => csv_core::QuoteStyle::NonNumeric,
+            QuoteStyle::Never => csv_core::QuoteStyle::Never,
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl Default for QuoteStyle {
+    fn default() -> QuoteStyle {
+        QuoteStyle::Necessary
+    }
+}
+
+/// A record terminator.
+///
+/// Use this to specify the record terminator while parsing CSV. The default is
+/// CRLF, which treats `\r`, `\n` or `\r\n` as a single record terminator.
+#[derive(Clone, Copy, Debug)]
+pub enum Terminator {
+    /// Parses `\r`, `\n` or `\r\n` as a single record terminator.
+    CRLF,
+    /// Parses the byte given as a record terminator.
+    Any(u8),
+    /// Hints that destructuring should not be exhaustive.
+    ///
+    /// This enum may grow additional variants, so this makes sure clients
+    /// don't count on exhaustive matching. (Otherwise, adding a new variant
+    /// could break existing code.)
+    #[doc(hidden)]
+    __Nonexhaustive,
+}
+
+impl Terminator {
+    /// Convert this to the csv_core type of the same name.
+    fn to_core(self) -> csv_core::Terminator {
+        match self {
+            Terminator::CRLF => csv_core::Terminator::CRLF,
+            Terminator::Any(b) => csv_core::Terminator::Any(b),
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl Default for Terminator {
+    fn default() -> Terminator {
+        Terminator::CRLF
+    }
+}
 
 /// A custom Serde deserializer for possibly invalid `Option<T>` fields.
 ///

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -5,13 +5,14 @@ use std::path::Path;
 use std::result;
 
 use csv_core::{
-    Reader as CoreReader, ReaderBuilder as CoreReaderBuilder, Terminator,
+    Reader as CoreReader, ReaderBuilder as CoreReaderBuilder,
 };
 use serde::de::DeserializeOwned;
 
 use byte_record::{self, ByteRecord, Position};
 use error::{Error, Result, Utf8Error};
 use string_record::{self, StringRecord};
+use Terminator;
 
 /// Builds a CSV reader with various configuration knobs.
 ///
@@ -352,7 +353,7 @@ impl ReaderBuilder {
         &mut self,
         term: Terminator,
     ) -> &mut ReaderBuilder {
-        self.builder.terminator(term);
+        self.builder.terminator(term.to_core());
         self
     }
 

--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -9,7 +9,7 @@ use serde::ser::{
     SerializeStructVariant,
 };
 
-use error::Error;
+use error::{Error, ErrorKind, new_error};
 use writer::Writer;
 
 /// Serialize the given value to the given writer, and return an error if
@@ -369,7 +369,7 @@ impl<'a, 'w, W: io::Write> SerializeStructVariant for &'a mut SeRecord<'w, W> {
 
 impl SerdeError for Error {
     fn custom<T: fmt::Display>(msg: T) -> Error {
-        Error::Serialize(msg.to_string())
+        new_error(ErrorKind::Serialize(msg.to_string()))
     }
 }
 
@@ -383,7 +383,7 @@ mod tests {
     use serde::Serialize;
     use serde_bytes::Bytes;
 
-    use error::Error;
+    use error::{Error, ErrorKind};
     use writer::Writer;
 
     use super::SeRecord;
@@ -567,9 +567,9 @@ mod tests {
 
         let err = serialize_err(
             false, false, Foo::X(false, 42, "hi".to_string()));
-        match err {
-            Error::Serialize(_) => {}
-            x => panic!("expected Error::Serialize but got '{:?}'", x),
+        match *err.kind() {
+            ErrorKind::Serialize(_) => {}
+            ref x => panic!("expected ErrorKind::Serialize but got '{:?}'", x),
         }
     }
 
@@ -582,9 +582,9 @@ mod tests {
 
         let err = serialize_err(
             false, false, Foo::X { a: false, b: 1, c: "hi".into() });
-        match err {
-            Error::Serialize(_) => {}
-            x => panic!("expected Error::Serialize but got '{:?}'", x),
+        match *err.kind() {
+            ErrorKind::Serialize(_) => {}
+            ref x => panic!("expected ErrorKind::Serialize but got '{:?}'", x),
         }
     }
 
@@ -641,9 +641,9 @@ mod tests {
         assert_eq!(got, "label,nest\n");
 
         let err = serialize_err(false, true, row.clone());
-        match err {
-            Error::Serialize(_) => {}
-            x => panic!("expected Error::Serialize but got '{:?}'", x),
+        match *err.kind() {
+            ErrorKind::Serialize(_) => {}
+            ref x => panic!("expected ErrorKind::Serialize but got '{:?}'", x),
         }
     }
 
@@ -660,9 +660,9 @@ mod tests {
         assert_eq!(got, "label,values\n");
 
         let err = serialize_err(false, true, row.clone());
-        match err {
-            Error::Serialize(_) => {}
-            x => panic!("expected Error::Serialize but got '{:?}'", x),
+        match *err.kind() {
+            ErrorKind::Serialize(_) => {}
+            ref x => panic!("expected ErrorKind::Serialize but got '{:?}'", x),
         }
     }
 }

--- a/src/string_record.rs
+++ b/src/string_record.rs
@@ -8,7 +8,7 @@ use std::str;
 use serde::de::Deserialize;
 
 use deserializer::deserialize_string_record;
-use error::{Error, FromUtf8Error, Result, new_from_utf8_error};
+use error::{ErrorKind, FromUtf8Error, Result, new_error, new_from_utf8_error};
 use reader::Reader;
 use byte_record::{self, ByteRecord, ByteRecordIter, Position};
 
@@ -42,7 +42,9 @@ pub fn read<R: io::Read>(
     };
     match (read_res, utf8_res) {
         (Err(err), _) => Err(err),
-        (Ok(_), Err(err)) => Err(Error::Utf8 { pos: Some(pos), err: err }),
+        (Ok(_), Err(err)) => {
+            Err(new_error(ErrorKind::Utf8 { pos: Some(pos), err: err }))
+        }
         (Ok(eof), Ok(())) => Ok(eof),
     }
 }

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -4,13 +4,13 @@ use std::path::Path;
 use std::result;
 
 use csv_core::{
-    Writer as CoreWriter, WriterBuilder as CoreWriterBuilder,
-    QuoteStyle, Terminator, WriteResult,
+    Writer as CoreWriter, WriterBuilder as CoreWriterBuilder, WriteResult,
 };
 use serde::Serialize;
 
 use error::{Error, Result, IntoInnerError, new_into_inner_error};
 use serializer::serialize;
+use {QuoteStyle, Terminator};
 
 /// Builds a CSV writer with various configuration knobs.
 ///
@@ -336,7 +336,7 @@ impl WriterBuilder {
         &mut self,
         term: Terminator,
     ) -> &mut WriterBuilder {
-        self.builder.terminator(term);
+        self.builder.terminator(term.to_core());
         self
     }
 
@@ -397,7 +397,7 @@ impl WriterBuilder {
     /// }
     /// ```
     pub fn quote_style(&mut self, style: QuoteStyle) -> &mut WriterBuilder {
-        self.builder.quote_style(style);
+        self.builder.quote_style(style.to_core());
         self
     }
 


### PR DESCRIPTION
It turns out that I hadn't put a lot of work (read: none) into optimizing the CSV writers, and there was a lot left on the table. This PR, among other things, optimizes both the csv-core and csv writers. It also introduces a new public method, `Writer::write_byte_record`, which takes a `&ByteRecord` directly instead of a generic iterator. When given a byte record, it is possible to perform a faster write.

"among other things" are:

* The `QuoteStyle` and `Terminator` types are no longer re-exported through `csv` from `csv-core`, which would make `csv-core` a public dependency on `csv`. Instead, we just re-define the types. We also make exhaustive case analysis impossible on these types so that we may add variants later.
* The `Error` type was changed from a public enum to a struct whose contents are private. A new `ErrorKind` public enum type was added, which permits callers to inspect the error. This change was motivated by a desire to box the error internally, since the error type had grown to be quite large. This makes all of the `Result<T, csv::Error>` types quite a bit more lightweight. Note though that this is a **breaking change**.