### PR TITLE
Eliminate "illegal for this to emit an output byte without consuming the input byte" possibility by using an enum

### DIFF
--- a/csv-core/src/reader.rs
+++ b/csv-core/src/reader.rs
@@ -933,9 +933,6 @@ impl Reader {
     /// This returns the next NFA state along with an NfaInputAction that
     /// indicates what should be done with the input byte (nothing for an epsilon
     /// transition, copied to a caller provided output buffer, or discarded).
-    ///
-    /// Note that this is more like a DFA than a true NFA; you cannot transition
-    /// to multiple states.
     #[inline(always)]
     fn transition_nfa(
         &self,


### PR DESCRIPTION
I was reading your code to see how the DFA transformation worked. The pair of booleans returned from transition_nfa seemed like a "smell," so I changed it to an enum. Tests pass and benchmark results are unchanged (this initialization code isn't the hot-path).

Change transition_nfa to return an NfaInputAction enum instead of a pair of booleans. Only 3 of the 4 possibilities were allowed, enforced by documentation and an assert. Now perhaps slightly clearer what each state transition is doing.
