### PR TITLE
Accept whitespace trimming settings

### DIFF
--- a/csv-core/src/reader.rs
+++ b/csv-core/src/reader.rs
@@ -1,6 +1,6 @@
 use core::fmt;
 
-use Terminator;
+use {Terminator};
 
 // BE ADVISED
 //

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -286,6 +286,42 @@ impl Default for Terminator {
     }
 }
 
+/// The whitespace preservation behaviour when reading CSV data.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum Trim {
+    /// Preserves fields and headers.
+    None,
+    /// Trim whitespace from headers.
+    Headers,
+    /// Trim whitespace from fields.
+    Fields,
+    /// Trim whitespace from fields and headers.
+    All,
+    /// Hints that destructuring should not be exhaustive.
+    ///
+    /// This enum may grow additional variants, so this makes sure clients
+    /// don't count on exhaustive matching. (Otherwise, adding a new variant
+    /// could break existing code.)
+    #[doc(hidden)]
+    __Nonexhaustive,
+}
+
+impl Trim {
+    fn should_trim_fields(trim: Trim) -> bool {
+        trim == Trim::Fields || trim == Trim::All
+    }
+
+    fn should_trim_headers(trim: Trim) -> bool {
+        trim == Trim::Headers || trim == Trim::All
+    }
+}
+
+impl Default for Trim {
+    fn default() -> Trim {
+        Trim::None
+    }
+}
+
 /// A custom Serde deserializer for possibly invalid `Option<T>` fields.
 ///
 /// When deserializing CSV data, it is sometimes desirable to simply ignore

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -5,14 +5,14 @@ use std::path::Path;
 use std::result;
 
 use csv_core::{
-    Reader as CoreReader, ReaderBuilder as CoreReaderBuilder,
+    Reader as CoreReader, ReaderBuilder as CoreReaderBuilder
 };
 use serde::de::DeserializeOwned;
 
 use byte_record::{self, ByteRecord, Position};
 use error::{ErrorKind, Result, Utf8Error, new_error};
 use string_record::{self, StringRecord};
-use Terminator;
+use {Terminator, Trim};
 
 /// Builds a CSV reader with various configuration knobs.
 ///
@@ -24,6 +24,7 @@ pub struct ReaderBuilder {
     capacity: usize,
     flexible: bool,
     has_headers: bool,
+    trim: Trim,
     /// The underlying CSV parser builder.
     ///
     /// We explicitly put this on the heap because CoreReaderBuilder embeds an
@@ -38,6 +39,7 @@ impl Default for ReaderBuilder {
             capacity: 8 * (1<<10),
             flexible: false,
             has_headers: true,
+            trim: Trim::default(),
             builder: Box::new(CoreReaderBuilder::default()),
         }
     }
@@ -316,6 +318,12 @@ impl ReaderBuilder {
     /// ```
     pub fn flexible(&mut self, yes: bool) -> &mut ReaderBuilder {
         self.flexible = yes;
+        self
+    }
+
+    /// Set whitespace preservation behaviour
+    pub fn trim(&mut self, trim: Trim) -> &mut ReaderBuilder {
+        self.trim = trim;
         self
     }
 
@@ -710,6 +718,7 @@ struct ReaderState {
     /// set, every record must have the same number of fields, or else an error
     /// is reported.
     flexible: bool,
+    trim: Trim,
     /// The number of fields in the first record parsed.
     first_field_count: Option<u64>,
     /// The current position of the parser.
@@ -776,6 +785,7 @@ impl<R: io::Read> Reader<R> {
                 headers: None,
                 has_headers: builder.has_headers,
                 flexible: builder.flexible,
+                trim: builder.trim,
                 first_field_count: None,
                 cur_pos: Position::new(),
                 first: false,
@@ -1447,18 +1457,34 @@ impl<R: io::Read> Reader<R> {
     ) {
         // If we have string headers, then get byte headers. But if we have
         // byte headers, then get the string headers (or a UTF-8 error).
-        let (str_headers, byte_headers) = match headers {
+        let (mut str_headers, mut byte_headers) = match headers {
             Ok(string) => {
                 let bytes = string.clone().into_byte_record();
                 (Ok(string), bytes)
             }
             Err(bytes) => {
                 match StringRecord::from_byte_record(bytes.clone()) {
-                    Ok(str_headers) => (Ok(str_headers), bytes),
-                    Err(err) => (Err(err.utf8_error().clone()), bytes),
+                    Ok(str_headers) => {
+                        (Ok(str_headers), bytes)
+                    },
+                    Err(err) => {
+                        (Err(err.utf8_error().clone()), bytes)
+                    },
                 }
             }
         };
+
+        if Trim::should_trim_headers(self.state.trim) {
+            let _ = str_headers.as_mut().map(|record| record.trim());
+            byte_headers = match str_headers.as_ref() {
+                Ok(record) => record.clone().into_byte_record(),
+                Err(_) => {
+                    byte_headers.trim();
+                    byte_headers
+                }
+            }
+        }
+
         self.state.headers = Some(Headers {
             byte_record: byte_headers,
             string_record: str_headers,
@@ -1505,7 +1531,11 @@ impl<R: io::Read> Reader<R> {
     /// }
     /// ```
     pub fn read_record(&mut self, record: &mut StringRecord) -> Result<bool> {
-        string_record::read(self, record)
+        let result = string_record::read(self, record);
+        if Trim::should_trim_fields(self.state.trim) {
+            record.trim();
+        }
+        result
     }
 
     /// Read a single row into the given byte record. Returns false when no
@@ -1558,6 +1588,9 @@ impl<R: io::Read> Reader<R> {
             if let Some(ref headers) = self.state.headers {
                 self.state.first = true;
                 record.clone_from(&headers.byte_record);
+                if Trim::should_trim_fields(self.state.trim) {
+                    record.trim();
+                }
                 return Ok(!record.is_empty());
             }
         }
@@ -1569,8 +1602,14 @@ impl<R: io::Read> Reader<R> {
             // never return the first row. Instead, we should attempt to
             // read and return the next one.
             if self.state.has_headers {
-                return self.read_byte_record_impl(record);
+                let result = self.read_byte_record_impl(record);
+                if Trim::should_trim_fields(self.state.trim) {
+                    record.trim();
+                }
+                return result;
             }
+        } else if Trim::should_trim_fields(self.state.trim) {
+            record.trim();
         }
         Ok(ok)
     }
@@ -2134,7 +2173,7 @@ mod tests {
     use error::ErrorKind;
     use string_record::StringRecord;
 
-    use super::{ReaderBuilder, Position};
+    use super::{ReaderBuilder, Position, Trim};
 
     fn b(s: &str) -> &[u8] { s.as_bytes() }
     fn s(b: &[u8]) -> &str { ::std::str::from_utf8(b).unwrap() }
@@ -2166,6 +2205,102 @@ mod tests {
         assert_eq!("xyz", s(&rec[2]));
 
         assert!(!rdr.read_byte_record(&mut rec).unwrap());
+    }
+
+    #[test]
+    fn read_trimmed_records_and_headers() {
+        let data = b("foo,  bar,\tbaz\n  1,  2,  3\n1\t,\t,3\t\t");
+        let mut rdr = ReaderBuilder::new()
+            .has_headers(true)
+            .trim(Trim::All)
+            .from_reader(data);
+        let mut rec = ByteRecord::new();
+        assert!(rdr.read_byte_record(&mut rec).unwrap());
+        assert_eq!("1", s(&rec[0]));
+        assert_eq!("2", s(&rec[1]));
+        assert_eq!("3", s(&rec[2]));
+        let mut rec = StringRecord::new();
+        assert!(rdr.read_record(&mut rec).unwrap());
+        assert_eq!("1", &rec[0]);
+        assert_eq!("", &rec[1]);
+        assert_eq!("3", &rec[2]);
+        {
+            let headers = rdr.headers().unwrap();
+            assert_eq!(3, headers.len());
+            assert_eq!("foo", &headers[0]);
+            assert_eq!("bar", &headers[1]);
+            assert_eq!("baz", &headers[2]);
+        }
+    }
+
+    #[test]
+    fn read_trimmed_header() {
+        let data = b("foo,  bar,\tbaz\n  1,  2,  3\n1\t,\t,3\t\t");
+        let mut rdr = ReaderBuilder::new()
+            .has_headers(true)
+            .trim(Trim::Headers)
+            .from_reader(data);
+        let mut rec = ByteRecord::new();
+        assert!(rdr.read_byte_record(&mut rec).unwrap());
+        assert_eq!("  1", s(&rec[0]));
+        assert_eq!("  2", s(&rec[1]));
+        assert_eq!("  3", s(&rec[2]));
+        {
+            let headers = rdr.headers().unwrap();
+            assert_eq!(3, headers.len());
+            assert_eq!("foo", &headers[0]);
+            assert_eq!("bar", &headers[1]);
+            assert_eq!("baz", &headers[2]);
+        }
+    }
+
+    #[test]
+    fn read_trimed_header_invalid_utf8() {
+        let data = &b"foo,  b\xFFar,\tbaz\na,b,c\nd,e,f"[..];
+        let mut rdr = ReaderBuilder::new()
+            .has_headers(true)
+            .trim(Trim::Headers)
+            .from_reader(data);
+        let mut rec = StringRecord::new();
+
+        let _ = rdr.read_record(&mut rec);  // force the headers to be read
+        // Check the byte headers are trimmed and string headers are still errors
+        {
+            let headers = rdr.byte_headers().unwrap();
+            assert_eq!(3, headers.len());
+            assert_eq!(b"foo", &headers[0]);
+            assert_eq!(b"b\xFFar", &headers[1]);
+            assert_eq!(b"baz", &headers[2]);
+        }
+        match *rdr.headers().unwrap_err().kind() {
+            ErrorKind::Utf8 { pos: Some(ref pos), ref err } => {
+                assert_eq!(pos, &newpos(0, 1, 0));
+                assert_eq!(err.field(), 1);
+                assert_eq!(err.valid_up_to(), 3);
+            }
+            ref err => panic!("match failed, got {:?}", err),
+        }
+    }
+
+    #[test]
+    fn read_trimmed_records() {
+        let data = b("foo,  bar,\tbaz\n  1,  2,  3\n1\t,\t,3\t\t");
+        let mut rdr = ReaderBuilder::new()
+            .has_headers(true)
+            .trim(Trim::Fields)
+            .from_reader(data);
+        let mut rec = ByteRecord::new();
+        assert!(rdr.read_byte_record(&mut rec).unwrap());
+        assert_eq!("1", s(&rec[0]));
+        assert_eq!("2", s(&rec[1]));
+        assert_eq!("3", s(&rec[2]));
+        {
+            let headers = rdr.headers().unwrap();
+            assert_eq!(3, headers.len());
+            assert_eq!("foo", &headers[0]);
+            assert_eq!("  bar", &headers[1]);
+            assert_eq!("\tbaz", &headers[2]);
+        }
     }
 
     #[test]


### PR DESCRIPTION
Fixes burntsushi/rust-csv#78

Per my comment in #78, I'm popping whitespace and updating the record bounds to reflect the changes.

Some thoughts:
* I don't know if match or if statements are more idiomatic in this case. Let me know if you have an opinion.
* If the user turns off headers then I apply trimming to the first row if `Trim::All` or `Trim::Fields` are set. I think this is reasonable but I could imagine that maybe `Trim::Headers` should be `Trim::FirstRow` or something in which case it isn't reasonable.
* Just now I was thinking maybe `Trim::Fields` should be `Trim::Records` instead.