### PR TITLE
refactor: make serde an optional dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,12 +23,15 @@ members = ["csv-core", "csv-index"]
 [lib]
 bench = false
 
+[features]
+default = ["serde"]
+
 [dependencies]
 bstr = { version = "0.2.1", features = ["serde1"] }
 csv-core = { path = "csv-core", version = "0.1.6" }
 itoa = "0.4.3"
 ryu = "1"
-serde = "1.0.55"
+serde = { version = "1.0.55", optional = true }
 
 [dev-dependencies]
 serde = { version = "1.0.55", features = ["derive"] }
@@ -38,3 +41,63 @@ debug = true
 
 [profile.bench]
 debug = true
+
+[[bench]]
+name = "bench"
+required-features = ["serde"]
+
+[[example]]
+name = "cookbook-read-serde"
+required-features = ["serde"]
+
+[[example]]
+name = "cookbook-write-serde"
+required-features = ["serde"]
+
+[[example]]
+name = "tutorial-perf-serde-01"
+required-features = ["serde"]
+
+[[example]]
+name = "tutorial-perf-serde-02"
+required-features = ["serde"]
+
+[[example]]
+name = "tutorial-perf-serde-03"
+required-features = ["serde"]
+
+[[example]]
+name = "tutorial-read-serde-01"
+required-features = ["serde"]
+
+[[example]]
+name = "tutorial-read-serde-02"
+required-features = ["serde"]
+
+[[example]]
+name = "tutorial-read-serde-03"
+required-features = ["serde"]
+
+[[example]]
+name = "tutorial-pipeline-pop-01"
+required-features = ["serde"]
+
+[[example]]
+name = "tutorial-read-serde-04"
+required-features = ["serde"]
+
+[[example]]
+name = "tutorial-read-serde-invalid-01"
+required-features = ["serde"]
+
+[[example]]
+name = "tutorial-read-serde-invalid-02"
+required-features = ["serde"]
+
+[[example]]
+name = "tutorial-write-serde-01"
+required-features = ["serde"]
+
+[[example]]
+name = "tutorial-write-serde-02"
+required-features = ["serde"]

--- a/src/byte_record.rs
+++ b/src/byte_record.rs
@@ -10,9 +10,9 @@ use serde::de::Deserialize;
 
 #[cfg(feature = "serde")]
 use crate::deserializer::deserialize_byte_record;
-use crate::error::{new_utf8_error, Utf8Error};
 #[cfg(feature = "serde")]
 use crate::error::Result;
+use crate::error::{new_utf8_error, Utf8Error};
 use crate::string_record::StringRecord;
 
 /// A single CSV record stored as raw bytes.

--- a/src/byte_record.rs
+++ b/src/byte_record.rs
@@ -5,10 +5,14 @@ use std::ops::{self, Range};
 use std::result;
 
 use bstr::{BString, ByteSlice};
+#[cfg(feature = "serde")]
 use serde::de::Deserialize;
 
+#[cfg(feature = "serde")]
 use crate::deserializer::deserialize_byte_record;
-use crate::error::{new_utf8_error, Result, Utf8Error};
+use crate::error::{new_utf8_error, Utf8Error};
+#[cfg(feature = "serde")]
+use crate::error::Result;
 use crate::string_record::StringRecord;
 
 /// A single CSV record stored as raw bytes.
@@ -226,6 +230,7 @@ impl ByteRecord {
     ///     Ok(())
     /// }
     /// ```
+    #[cfg(feature = "serde")]
     pub fn deserialize<'de, D: Deserialize<'de>>(
         &'de self,
         headers: Option<&'de ByteRecord>,

--- a/src/cookbook.rs
+++ b/src/cookbook.rs
@@ -62,7 +62,8 @@ $ git clone git://github.com/BurntSushi/rust-csv
 $ cd rust-csv
 $ cargo run --example cookbook-read-basic < examples/data/smallpop.csv
 ```
-
+*/
+#![cfg_attr(feature = "serde", doc = r#"
 # Reading: with Serde
 
 This is like the previous example, except it shows how to deserialize each
@@ -116,7 +117,8 @@ $ git clone git://github.com/BurntSushi/rust-csv
 $ cd rust-csv
 $ cargo run --example cookbook-read-serde < examples/data/smallpop.csv
 ```
-
+"#)]
+/*!
 # Reading: setting a different delimiter
 
 This example shows how to read CSV data from stdin where fields are separated
@@ -232,7 +234,8 @@ $ git clone git://github.com/BurntSushi/rust-csv
 $ cd rust-csv
 $ cargo run --example cookbook-write-basic > /tmp/simplepop.csv
 ```
-
+*/
+#![cfg_attr(feature = "serde", doc = r#"
 # Writing: with Serde
 
 This example shows how to write CSV data to stdout with Serde. Namely, we
@@ -291,4 +294,4 @@ $ git clone git://github.com/BurntSushi/rust-csv
 $ cd rust-csv
 $ cargo run --example cookbook-write-serde > /tmp/simplepop.csv
 ```
-*/
+"#)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,6 +4,7 @@ use std::io;
 use std::result;
 
 use crate::byte_record::{ByteRecord, Position};
+#[cfg(feature = "serde")]
 use crate::deserializer::DeserializeError;
 
 /// A type alias for `Result<T, csv::Error>`.
@@ -89,9 +90,11 @@ pub enum ErrorKind {
     /// the first record.
     Seek,
     /// An error of this kind occurs only when using the Serde serializer.
+    #[cfg(feature = "serde")]
     Serialize(String),
     /// An error of this kind occurs only when performing automatic
     /// deserialization with serde.
+    #[cfg(feature = "serde")]
     Deserialize {
         /// The position of this error, if available.
         pos: Option<Position>,
@@ -116,6 +119,7 @@ impl ErrorKind {
         match *self {
             ErrorKind::Utf8 { ref pos, .. } => pos.as_ref(),
             ErrorKind::UnequalLengths { ref pos, .. } => pos.as_ref(),
+            #[cfg(feature = "serde")]
             ErrorKind::Deserialize { ref pos, .. } => pos.as_ref(),
             _ => None,
         }
@@ -141,7 +145,9 @@ impl StdError for Error {
             ErrorKind::Utf8 { ref err, .. } => Some(err),
             ErrorKind::UnequalLengths { .. } => None,
             ErrorKind::Seek => None,
+            #[cfg(feature = "serde")]
             ErrorKind::Serialize(_) => None,
+            #[cfg(feature = "serde")]
             ErrorKind::Deserialize { ref err, .. } => Some(err),
             _ => unreachable!(),
         }
@@ -195,12 +201,15 @@ impl fmt::Display for Error {
                  when the parser was seeked before the first record \
                  could be read"
             ),
+            #[cfg(feature = "serde")]
             ErrorKind::Serialize(ref err) => {
                 write!(f, "CSV write error: {}", err)
             }
+            #[cfg(feature = "serde")]
             ErrorKind::Deserialize { pos: None, ref err } => {
                 write!(f, "CSV deserialize error: {}", err)
             }
+            #[cfg(feature = "serde")]
             ErrorKind::Deserialize { pos: Some(ref pos), ref err } => write!(
                 f,
                 "CSV deserialize error: record {} \

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,7 +96,8 @@ $ git clone git://github.com/BurntSushi/rust-csv
 $ cd rust-csv
 $ cargo run --example cookbook-read-basic < examples/data/smallpop.csv
 ```
-
+*/
+#![cfg_attr(feature = "serde", doc = r#"
 # Example with Serde
 
 This example shows how to read CSV data from stdin into your own custom struct.
@@ -144,33 +145,38 @@ $ git clone git://github.com/BurntSushi/rust-csv
 $ cd rust-csv
 $ cargo run --example cookbook-read-serde < examples/data/smallpop.csv
 ```
-
-*/
+"#)]
 
 #![deny(missing_docs)]
 
+#[cfg(feature = "serde")]
 use std::result;
 
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Deserializer};
 
 pub use crate::byte_record::{ByteRecord, ByteRecordIter, Position};
+#[cfg(feature = "serde")]
 pub use crate::deserializer::{DeserializeError, DeserializeErrorKind};
 pub use crate::error::{
     Error, ErrorKind, FromUtf8Error, IntoInnerError, Result, Utf8Error,
 };
 pub use crate::reader::{
-    ByteRecordsIntoIter, ByteRecordsIter, DeserializeRecordsIntoIter,
-    DeserializeRecordsIter, Reader, ReaderBuilder, StringRecordsIntoIter,
-    StringRecordsIter,
+    ByteRecordsIntoIter, ByteRecordsIter, Reader, ReaderBuilder,
+    StringRecordsIntoIter, StringRecordsIter,
 };
+#[cfg(feature = "serde")]
+pub use crate::reader::{DeserializeRecordsIntoIter, DeserializeRecordsIter};
 pub use crate::string_record::{StringRecord, StringRecordIter};
 pub use crate::writer::{Writer, WriterBuilder};
 
 mod byte_record;
 pub mod cookbook;
+#[cfg(feature = "serde")]
 mod deserializer;
 mod error;
 mod reader;
+#[cfg(feature = "serde")]
 mod serializer;
 mod string_record;
 pub mod tutorial;
@@ -350,6 +356,7 @@ impl Default for Trim {
 ///     }
 /// }
 /// ```
+#[cfg(feature = "serde")]
 pub fn invalid_option<'de, D, T>(de: D) -> result::Result<Option<T>, D::Error>
 where
     D: Deserializer<'de>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,7 +97,9 @@ $ cd rust-csv
 $ cargo run --example cookbook-read-basic < examples/data/smallpop.csv
 ```
 */
-#![cfg_attr(feature = "serde", doc = r#"
+#![cfg_attr(
+    feature = "serde",
+    doc = r#"
 # Example with Serde
 
 This example shows how to read CSV data from stdin into your own custom struct.
@@ -145,8 +147,8 @@ $ git clone git://github.com/BurntSushi/rust-csv
 $ cd rust-csv
 $ cargo run --example cookbook-read-serde < examples/data/smallpop.csv
 ```
-"#)]
-
+"#
+)]
 #![deny(missing_docs)]
 
 #[cfg(feature = "serde")]

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1,10 +1,12 @@
 use std::fs::File;
 use std::io::{self, BufRead, Seek};
+#[cfg(feature = "serde")]
 use std::marker::PhantomData;
 use std::path::Path;
 use std::result;
 
 use csv_core::{Reader as CoreReader, ReaderBuilder as CoreReaderBuilder};
+#[cfg(feature = "serde")]
 use serde::de::DeserializeOwned;
 
 use crate::byte_record::{ByteRecord, Position};
@@ -1017,6 +1019,7 @@ impl<R: io::Read> Reader<R> {
     ///     }
     /// }
     /// ```
+    #[cfg(feature = "serde")]
     pub fn deserialize<D>(&mut self) -> DeserializeRecordsIter<R, D>
     where
         D: DeserializeOwned,
@@ -1080,6 +1083,7 @@ impl<R: io::Read> Reader<R> {
     ///     }
     /// }
     /// ```
+    #[cfg(feature = "serde")]
     pub fn into_deserialize<D>(self) -> DeserializeRecordsIntoIter<R, D>
     where
         D: DeserializeOwned,
@@ -1877,6 +1881,7 @@ impl ReaderState {
 ///
 /// The type parameter `R` refers to the underlying `io::Read` type, and `D`
 /// refers to the type that this iterator will deserialize a record into.
+#[cfg(feature = "serde")]
 pub struct DeserializeRecordsIntoIter<R, D> {
     rdr: Reader<R>,
     rec: StringRecord,
@@ -1884,6 +1889,7 @@ pub struct DeserializeRecordsIntoIter<R, D> {
     _priv: PhantomData<D>,
 }
 
+#[cfg(feature = "serde")]
 impl<R: io::Read, D: DeserializeOwned> DeserializeRecordsIntoIter<R, D> {
     fn new(mut rdr: Reader<R>) -> DeserializeRecordsIntoIter<R, D> {
         let headers = if !rdr.state.has_headers {
@@ -1915,6 +1921,7 @@ impl<R: io::Read, D: DeserializeOwned> DeserializeRecordsIntoIter<R, D> {
     }
 }
 
+#[cfg(feature = "serde")]
 impl<R: io::Read, D: DeserializeOwned> Iterator
     for DeserializeRecordsIntoIter<R, D>
 {
@@ -1935,6 +1942,7 @@ impl<R: io::Read, D: DeserializeOwned> Iterator
 /// CSV `Reader`. The type parameter `R` refers to the underlying `io::Read`
 /// type, and `D` refers to the type that this iterator will deserialize a
 /// record into.
+#[cfg(feature = "serde")]
 pub struct DeserializeRecordsIter<'r, R: 'r, D> {
     rdr: &'r mut Reader<R>,
     rec: StringRecord,
@@ -1942,6 +1950,7 @@ pub struct DeserializeRecordsIter<'r, R: 'r, D> {
     _priv: PhantomData<D>,
 }
 
+#[cfg(feature = "serde")]
 impl<'r, R: io::Read, D: DeserializeOwned> DeserializeRecordsIter<'r, R, D> {
     fn new(rdr: &'r mut Reader<R>) -> DeserializeRecordsIter<'r, R, D> {
         let headers = if !rdr.state.has_headers {
@@ -1968,6 +1977,7 @@ impl<'r, R: io::Read, D: DeserializeOwned> DeserializeRecordsIter<'r, R, D> {
     }
 }
 
+#[cfg(feature = "serde")]
 impl<'r, R: io::Read, D: DeserializeOwned> Iterator
     for DeserializeRecordsIter<'r, R, D>
 {

--- a/src/string_record.rs
+++ b/src/string_record.rs
@@ -5,9 +5,11 @@ use std::ops::{self, Range};
 use std::result;
 use std::str;
 
+#[cfg(feature = "serde")]
 use serde::de::Deserialize;
 
 use crate::byte_record::{ByteRecord, ByteRecordIter, Position};
+#[cfg(feature = "serde")]
 use crate::deserializer::deserialize_string_record;
 use crate::error::{Error, ErrorKind, FromUtf8Error, Result};
 use crate::reader::Reader;
@@ -289,6 +291,7 @@ impl StringRecord {
     ///     Ok(())
     /// }
     /// ```
+    #[cfg(feature = "serde")]
     pub fn deserialize<'de, D: Deserialize<'de>>(
         &'de self,
         headers: Option<&'de StringRecord>,

--- a/src/tutorial.rs
+++ b/src/tutorial.rs
@@ -708,7 +708,8 @@ is `CRLF`, which treats each of `\r\n`, `\r` and `\n` as single record
 terminators.) For more details, see the documentation and examples for each of
 the methods on
 [`ReaderBuilder`](../struct.ReaderBuilder.html).
-
+*/
+#![cfg_attr(feature = "serde", doc = r#"
 ## Reading with Serde
 
 One of the most convenient features of this crate is its support for
@@ -1153,7 +1154,8 @@ The
 function is a generic helper function that does one very simple thing: when
 applied to `Option` fields, it will convert any deserialization error into a
 `None` value. This is useful when you need to work with messy CSV data.
-
+#")]
+/*!
 # Writing CSV
 
 In this section we'll show a few examples that write CSV data. Writing CSV data
@@ -1379,7 +1381,8 @@ to you. The default is to add quotes to fields only when necessary. This
 probably works for most use cases, but you can also ask for quotes to always
 be put around fields, to never be put around fields or to always be put around
 non-numeric fields.
-
+*/
+#![cfg_attr(feature = "serde", doc = r#"
 ## Writing with Serde
 
 Just like the CSV reader supports automatic deserialization into Rust types
@@ -1571,7 +1574,8 @@ For more examples and more details on the rules for serialization, please see
 the
 [`Writer::serialize`](../struct.Writer.html#method.serialize)
 method.
-
+#")]
+/*!
 # Pipelining
 
 In this section, we're going to cover a few examples that demonstrate programs
@@ -1755,7 +1759,8 @@ $ ./csvtutor MA < uspop-latin1.csv
 City,State,Population,Latitude,Longitude
 Reading,MA,23441,42.5255556,-71.0958333
 ```
-
+*/
+#![cfg_attr(feature = "serde", doc = r#"
 ## Filter by population count
 
 In this section, we will show another example program that both reads and
@@ -1857,7 +1862,8 @@ Fontana,CA,169160,34.0922222,-117.4341667
 Bridgeport,CT,139090,41.1669444,-73.2052778
 Indianapolis,IN,773283,39.7683333,-86.1580556
 ```
-
+#")]
+/*!
 # Performance
 
 In this section, we'll go over how to squeeze the most juice out of our CSV
@@ -2124,7 +2130,8 @@ An exercise you might consider doing is to use a `StringRecord` instead of a
 instead of `read_byte_record`. This will give you easy access to Rust strings
 at the cost of UTF-8 validation but *without* the cost of allocating a new
 `StringRecord` for every record.
-
+*/
+#![cfg_attr(feature = "serde", doc = r#"
 ## Serde and zero allocation
 
 In this section, we are going to briefly examine how we use Serde and what we
@@ -2355,7 +2362,8 @@ over the first example.
 
 In sum, Serde parsing is still quite fast, but will generally not be the
 fastest way to parse CSV since it necessarily needs to do more work.
-
+"#)]
+/*!
 ## CSV parsing without the standard library
 
 In this section, we will explore a niche use case: parsing CSV without the

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -7,10 +7,12 @@ use csv_core::{
     self, WriteResult, Writer as CoreWriter,
     WriterBuilder as CoreWriterBuilder,
 };
+#[cfg(feature = "serde")]
 use serde::Serialize;
 
 use crate::byte_record::ByteRecord;
 use crate::error::{Error, ErrorKind, IntoInnerError, Result};
+#[cfg(feature = "serde")]
 use crate::serializer::{serialize, serialize_header};
 use crate::{QuoteStyle, Terminator};
 
@@ -24,6 +26,7 @@ pub struct WriterBuilder {
     builder: CoreWriterBuilder,
     capacity: usize,
     flexible: bool,
+    #[cfg(feature = "serde")]
     has_headers: bool,
 }
 
@@ -33,6 +36,7 @@ impl Default for WriterBuilder {
             builder: CoreWriterBuilder::default(),
             capacity: 8 * (1 << 10),
             flexible: false,
+            #[cfg(feature = "serde")]
             has_headers: true,
         }
     }
@@ -227,6 +231,7 @@ impl WriterBuilder {
     ///     Ok(())
     /// }
     /// ```
+    #[cfg(feature = "serde")]
     pub fn has_headers(&mut self, yes: bool) -> &mut WriterBuilder {
         self.has_headers = yes;
         self
@@ -515,6 +520,7 @@ pub struct Writer<W: io::Write> {
 #[derive(Debug)]
 struct WriterState {
     /// Whether the Serde serializer should attempt to write a header row.
+    #[cfg(feature = "serde")]
     header: HeaderState,
     /// Whether inconsistent record lengths are allowed.
     flexible: bool,
@@ -533,6 +539,7 @@ struct WriterState {
 
 /// HeaderState encodes a small state machine for handling header writes.
 #[derive(Debug)]
+#[cfg(feature = "serde")]
 enum HeaderState {
     /// Indicates that we should attempt to write a header.
     Write,
@@ -595,6 +602,7 @@ impl Writer<File> {
 
 impl<W: io::Write> Writer<W> {
     fn new(builder: &WriterBuilder, wtr: W) -> Writer<W> {
+        #[cfg(feature = "serde")]
         let header_state = if builder.has_headers {
             HeaderState::Write
         } else {
@@ -605,6 +613,7 @@ impl<W: io::Write> Writer<W> {
             wtr: Some(wtr),
             buf: Buffer { buf: vec![0; builder.capacity], len: 0 },
             state: WriterState {
+                #[cfg(feature = "serde")]
                 header: header_state,
                 flexible: builder.flexible,
                 first_field_count: None,
@@ -849,6 +858,7 @@ impl<W: io::Write> Writer<W> {
     /// | `Foo { x: 5, y: (6, 7) }` | *error: restriction 1* | `5,6,7` |
     /// | `(5, Foo { x: 6, y: 7 }` | *error: restriction 2* | `5,6,7` |
     /// | `(Foo { x: 5, y: 6 }, true)` | *error: restriction 2* | `5,6,true` |
+    #[cfg(feature = "serde")]
     pub fn serialize<S: Serialize>(&mut self, record: S) -> Result<()> {
         if let HeaderState::Write = self.state.header {
             let wrote_header = serialize_header(self, &record)?;
@@ -1306,6 +1316,7 @@ mod tests {
         assert_eq!(wtr_as_string(wtr), "a,b,c\na\n");
     }
 
+    #[cfg(feature = "serde")]
     #[test]
     fn serialize_with_headers() {
         #[derive(Serialize)]
@@ -1320,6 +1331,7 @@ mod tests {
         assert_eq!(wtr_as_string(wtr), "foo,bar,baz\n42,42.5,true\n");
     }
 
+    #[cfg(feature = "serde")]
     #[test]
     fn serialize_no_headers() {
         #[derive(Serialize)]
@@ -1335,6 +1347,7 @@ mod tests {
         assert_eq!(wtr_as_string(wtr), "42,42.5,true\n");
     }
 
+    #[cfg(feature = "serde")]
     serde_if_integer128! {
         #[test]
         fn serialize_no_headers_128() {
@@ -1356,6 +1369,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "serde")]
     #[test]
     fn serialize_tuple() {
         let mut wtr = WriterBuilder::new().from_writer(vec![]);

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -26,6 +26,7 @@ fn cookbook_read_basic() {
     assert_eq!(out.stdout().lines().count(), 10);
 }
 
+#[cfg(feature = "serde")]
 #[test]
 fn cookbook_read_serde() {
     let mut cmd = cmd_for_example("cookbook-read-serde");
@@ -54,6 +55,7 @@ fn cookbook_write_basic() {
     assert_eq!(out.stdout().lines().count(), 3);
 }
 
+#[cfg(feature = "serde")]
 #[test]
 fn cookbook_write_serde() {
     let mut cmd = cmd_for_example("cookbook-write-serde");
@@ -173,6 +175,7 @@ fn tutorial_read_delimiter_01() {
     assert_eq!(out.stdout().lines().count(), 6);
 }
 
+#[cfg(feature = "serde")]
 #[test]
 fn tutorial_read_serde_01() {
     let mut cmd = cmd_for_example("tutorial-read-serde-01");
@@ -181,6 +184,7 @@ fn tutorial_read_serde_01() {
     assert!(out.stdout().lines().all(|x| x.contains("pop:")));
 }
 
+#[cfg(feature = "serde")]
 #[test]
 fn tutorial_read_serde_02() {
     let mut cmd = cmd_for_example("tutorial-read-serde-02");
@@ -189,6 +193,7 @@ fn tutorial_read_serde_02() {
     assert!(out.stdout().lines().all(|x| x.starts_with("(")));
 }
 
+#[cfg(feature = "serde")]
 #[test]
 fn tutorial_read_serde_03() {
     let mut cmd = cmd_for_example("tutorial-read-serde-03");
@@ -197,6 +202,7 @@ fn tutorial_read_serde_03() {
     assert!(out.stdout().lines().all(|x| x.contains("\"City\":")));
 }
 
+#[cfg(feature = "serde")]
 #[test]
 fn tutorial_read_serde_04() {
     let mut cmd = cmd_for_example("tutorial-read-serde-04");
@@ -205,6 +211,7 @@ fn tutorial_read_serde_04() {
     assert!(out.stdout().lines().all(|x| x.starts_with("Record { latitude:")));
 }
 
+#[cfg(feature = "serde")]
 #[test]
 fn tutorial_read_serde_05_invalid() {
     let mut cmd = cmd_for_example("tutorial-read-serde-invalid-01");
@@ -213,6 +220,7 @@ fn tutorial_read_serde_05_invalid() {
     assert!(out.stdout().lines().all(|x| x.starts_with("Record { latitude:")));
 }
 
+#[cfg(feature = "serde")]
 #[test]
 fn tutorial_read_serde_05_invalid_errored() {
     let mut cmd = cmd_for_example("tutorial-read-serde-invalid-01");
@@ -220,6 +228,7 @@ fn tutorial_read_serde_05_invalid_errored() {
     assert!(out.stdout_failed().contains("CSV deserialize error:"));
 }
 
+#[cfg(feature = "serde")]
 #[test]
 fn tutorial_read_serde_invalid_06() {
     let mut cmd = cmd_for_example("tutorial-read-serde-invalid-02");
@@ -243,6 +252,7 @@ fn tutorial_write_delimiter_01() {
     assert!(out.stdout().lines().all(|x| x.contains('\t')));
 }
 
+#[cfg(feature = "serde")]
 #[test]
 fn tutorial_write_serde_01() {
     let mut cmd = cmd_for_example("tutorial-write-serde-01");
@@ -250,6 +260,7 @@ fn tutorial_write_serde_01() {
     assert_eq!(out.stdout().lines().count(), 4);
 }
 
+#[cfg(feature = "serde")]
 #[test]
 fn tutorial_write_serde_02() {
     let mut cmd = cmd_for_example("tutorial-write-serde-02");
@@ -310,6 +321,7 @@ fn tutorial_perf_alloc_03() {
     assert_eq!(out.stdout(), "11\n");
 }
 
+#[cfg(feature = "serde")]
 #[test]
 fn tutorial_perf_serde_01() {
     let mut cmd = cmd_for_example("tutorial-perf-serde-01");
@@ -317,6 +329,7 @@ fn tutorial_perf_serde_01() {
     assert_eq!(out.stdout(), "11\n");
 }
 
+#[cfg(feature = "serde")]
 #[test]
 fn tutorial_perf_serde_02() {
     let mut cmd = cmd_for_example("tutorial-perf-serde-02");
@@ -324,6 +337,7 @@ fn tutorial_perf_serde_02() {
     assert_eq!(out.stdout(), "11\n");
 }
 
+#[cfg(feature = "serde")]
 #[test]
 fn tutorial_perf_serde_03() {
     let mut cmd = cmd_for_example("tutorial-perf-serde-03");


### PR DESCRIPTION
See title! Closes #126.

My concerns:

1. `Cargo.toml` took a beating with required features.
2. Doc comments with serde are ugly.

I think 2 is fine, but 1 feels awful.