### PR TITLE
inner_mut for Reader

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1625,16 +1625,17 @@ impl<R: io::Read> Reader<R> {
         loop {
             let (res, nin, nout, nend) = {
                 let input = self.rdr.fill_buf()?;
+                let (fields, ends) = record.as_parts();
+                let result = self.core.read_record(
+                    input,
+                    &mut fields[outlen..],
+                    &mut ends[endlen..],
+                );
                 if self.state.complete_only && input.is_empty() {
                     self.state.cur_pos = orig_pos;
                     return Ok(false);
                 }
-                let (fields, ends) = record.as_parts();
-                self.core.read_record(
-                    input,
-                    &mut fields[outlen..],
-                    &mut ends[endlen..],
-                )
+                result
             };
             self.rdr.consume(nin);
             let byte = self.state.cur_pos.byte();

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -853,7 +853,9 @@ impl<R: io::Read> Reader<R> {
     }
 
     /// Returns a mutable reference to the inner reader.
-    pub fn inner_mut(&mut self) -> &mut R { self.rdr.get_mut() }
+    pub fn inner_mut(&mut self) -> &mut R {
+        self.rdr.get_mut()
+    }
 
     /// Returns a borrowed iterator over deserialized records.
     ///

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -852,6 +852,9 @@ impl<R: io::Read> Reader<R> {
         ReaderBuilder::new().from_reader(rdr)
     }
 
+    /// Returns a mutable reference to the inner reader.
+    pub fn inner_mut(&mut self) -> &mut R { self.rdr.get_mut() }
+
     /// Returns a borrowed iterator over deserialized records.
     ///
     /// Each item yielded by this iterator is a `Result<D, Error>`.

--- a/tests/test_chunks.rs
+++ b/tests/test_chunks.rs
@@ -50,3 +50,73 @@ fn test_chunks() {
     assert_eq!(output[5].as_slice(), &b"4aaaa4bbbb4cccc"[..]);
     assert_eq!(output[6].as_slice(), &b"5aaaa5bbbb5cccc"[..]);
 }
+
+
+#[derive(Debug)]
+struct ChunkReader<'a> {
+    read: usize,
+    chunk: &'a [u8],
+    unparsed: Vec<u8>,
+}
+
+impl<'a> ChunkReader<'a> {
+    fn feed(&mut self, input: &'a [u8]) {
+        self.unparsed.extend_from_slice(self.chunk);
+        self.chunk = input;
+    }
+
+    fn consumed(&mut self, bytes: usize) {
+        let of_unparsed = std::cmp::min(self.unparsed.len(), bytes);
+        self.unparsed = self.unparsed.split_off(of_unparsed);
+        let of_read = bytes - of_unparsed;
+        self.chunk = &self.chunk[of_read..];
+        self.read = 0;
+    }
+}
+
+impl<'a> std::io::Read for ChunkReader<'a> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let internal = if self.read < self.unparsed.len() {
+            &self.unparsed[self.read..]
+        } else {
+            &self.chunk[(self.read - self.unparsed.len())..]
+        };
+        let len = std::cmp::min(buf.len(), internal.len());
+        buf[..len].copy_from_slice(&internal[..len]);
+        self.read += len;
+
+        Ok(len)
+    }
+}
+
+#[test]
+fn test_chunks_2() {
+    let input_chunks = vec![
+        &b"col_a,col_b,col_c\n0aaaa,0bbbb,0cccc\n1aaaa,1bbbb,1cc"[..],
+        &b"cc\n"[..],
+        &b"2aaaa,2bbbb"[..],
+        &b",2cccc\n"[..],
+        &b"3aaaa,3bbbb,3cccc\n4aaaa,4bbbb,4cccc\n5aaaa,5bb"[..],
+        &b"bb,5cccc"[..],
+        &b"\n"[..],
+        &b"6aaa"[..],
+    ];
+    let mut output = Vec::new();
+    let mut reader = csv::ReaderBuilder::new()
+        .complete_only(true)
+        .from_reader(ChunkReader{ read: 0, chunk: &[], unparsed: Vec::new() });
+    let mut bytes_parsed_prev = 0;
+    for chunk in input_chunks.iter() {
+        reader.inner_mut().feed(chunk);
+        output.extend(reader.byte_records().map(Result::unwrap));
+        let consumed = reader.position().byte() as usize - bytes_parsed_prev;
+        bytes_parsed_prev = reader.position().byte() as usize;
+        reader.inner_mut().consumed(consumed);
+    }
+    assert_eq!(output[0].as_slice(), &b"0aaaa0bbbb0cccc"[..]);
+    assert_eq!(output[1].as_slice(), &b"1aaaa1bbbb1cccc"[..]);
+    assert_eq!(output[2].as_slice(), &b"2aaaa2bbbb2cccc"[..]);
+    assert_eq!(output[3].as_slice(), &b"3aaaa3bbbb3cccc"[..]);
+    assert_eq!(output[4].as_slice(), &b"4aaaa4bbbb4cccc"[..]);
+    assert_eq!(output[5].as_slice(), &b"5aaaa5bbbb5cccc"[..]);
+}

--- a/tests/test_chunks.rs
+++ b/tests/test_chunks.rs
@@ -1,0 +1,54 @@
+use std::error::Error;
+use std::io::Read;
+use csv::ByteRecord;
+
+fn parse_csv(
+    chunk: impl Read,
+    output: &mut Vec<ByteRecord>,
+) -> Result<u64, Box<dyn Error>> {
+    let mut reader = csv::ReaderBuilder::new()
+        .has_headers(false)
+        .complete_only(true)
+        .from_reader(chunk);
+
+    output.extend(reader.byte_records().map(Result::unwrap));
+    Ok(reader.position().byte())
+}
+
+#[test]
+fn test_chunks() {
+    let input_chunks = vec![
+        &b"col_a,col_b,col_c\n0aaaa,0bbbb,0cccc\n1aaaa,1bbbb,1cc"[..],
+        &b"cc\n"[..],
+        &b"2aaaa,2bbbb"[..],
+        &b",2cccc\n"[..],
+        &b"3aaaa,3bbbb,3cccc\n4aaaa,4bbbb,4cccc\n5aaaa,5bb"[..],
+        &b"bb,5cccc"[..],
+        &b"\n"[..],
+        &b"6aaa"[..],
+    ];
+    let mut unparsed = Vec::new();
+    let mut next_unparsed = Vec::new();
+    let mut output = Vec::new();
+    for chunk in input_chunks.iter() {
+        let bytes_parsed = parse_csv(
+            Read::chain(unparsed.as_slice(), *chunk),
+            &mut output
+        )
+        .unwrap();
+        let stored_bytes_parsed =
+            std::cmp::min(bytes_parsed as usize, unparsed.len());
+        let chunk_bytes_parsed = bytes_parsed as usize - stored_bytes_parsed;
+        next_unparsed.extend_from_slice(&unparsed[stored_bytes_parsed..]);
+        next_unparsed.extend_from_slice(&chunk[chunk_bytes_parsed..]);
+        unparsed.truncate(0);
+        std::mem::swap(&mut unparsed, &mut next_unparsed);
+    }
+    assert_eq!(output[0].as_slice(), &b"col_acol_bcol_c"[..]);
+    assert_eq!(output[1].as_slice(), &b"0aaaa0bbbb0cccc"[..]);
+    assert_eq!(output[2].as_slice(), &b"1aaaa1bbbb1cccc"[..]);
+    assert_eq!(output[3].as_slice(), &b"2aaaa2bbbb2cccc"[..]);
+    assert_eq!(output[4].as_slice(), &b"3aaaa3bbbb3cccc"[..]);
+    assert_eq!(output[5].as_slice(), &b"4aaaa4bbbb4cccc"[..]);
+    assert_eq!(output[6].as_slice(), &b"5aaaa5bbbb5cccc"[..]);
+}

--- a/tests/test_chunks.rs
+++ b/tests/test_chunks.rs
@@ -1,6 +1,6 @@
+use csv::ByteRecord;
 use std::error::Error;
 use std::io::Read;
-use csv::ByteRecord;
 
 fn parse_csv(
     chunk: impl Read,
@@ -31,11 +31,9 @@ fn test_chunks() {
     let mut next_unparsed = Vec::new();
     let mut output = Vec::new();
     for chunk in input_chunks.iter() {
-        let bytes_parsed = parse_csv(
-            Read::chain(unparsed.as_slice(), *chunk),
-            &mut output
-        )
-        .unwrap();
+        let bytes_parsed =
+            parse_csv(Read::chain(unparsed.as_slice(), *chunk), &mut output)
+                .unwrap();
         let stored_bytes_parsed =
             std::cmp::min(bytes_parsed as usize, unparsed.len());
         let chunk_bytes_parsed = bytes_parsed as usize - stored_bytes_parsed;

--- a/tests/test_chunks.rs
+++ b/tests/test_chunks.rs
@@ -51,7 +51,6 @@ fn test_chunks() {
     assert_eq!(output[6].as_slice(), &b"5aaaa5bbbb5cccc"[..]);
 }
 
-
 #[derive(Debug)]
 struct ChunkReader<'a> {
     read: usize,
@@ -102,9 +101,10 @@ fn test_chunks_2() {
         &b"6aaa"[..],
     ];
     let mut output = Vec::new();
-    let mut reader = csv::ReaderBuilder::new()
-        .complete_only(true)
-        .from_reader(ChunkReader{ read: 0, chunk: &[], unparsed: Vec::new() });
+    let mut reader =
+        csv::ReaderBuilder::new().complete_only(true).from_reader(
+            ChunkReader { read: 0, chunk: &[], unparsed: Vec::new() },
+        );
     let mut bytes_parsed_prev = 0;
     for chunk in input_chunks.iter() {
         reader.inner_mut().feed(chunk);


### PR DESCRIPTION
More sketching around https://github.com/BurntSushi/rust-csv/issues/176#issuecomment-543547885

I found out that once `only_complete` is there, a method to get a mutable reference to the inner reader _will_ be helpful: it allows one to implement a feeder pattern demonstrated by `test_chunks_2` of `tests/test_chunks.rs`. This will allow incremental parsing without having to scrap and rebuild `Reader` for every chunk.

With these changes, incremental parsing would be, if not easy, at least a lot easier than before.