### PR TITLE
Remove deprecated std::error::Error::description and use CARGO_MANIFEST_DIR to find the examples/data/ for test cases

### DIFF
--- a/src/deserializer.rs
+++ b/src/deserializer.rs
@@ -738,6 +738,7 @@ impl DeserializeError {
 }
 
 impl DeserializeErrorKind {
+    #[allow(deprecated)]
     fn description(&self) -> &str {
         use self::DeserializeErrorKind::*;
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -358,12 +358,7 @@ fn example_bin_dir() -> PathBuf {
 
 /// Return the repo root directory path.
 fn repo_dir() -> PathBuf {
-    debug_dir()
-        .parent()
-        .expect("target directory")
-        .parent()
-        .expect("repo directory")
-        .to_path_buf()
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
 }
 
 /// Return the directory containing the example data.


### PR DESCRIPTION
Was looking for unsafe code to eliminate and deprecated warnings to resolve. So far I've only done the latter. Please reconsider how you use unsafe code. Yes, this appears safe.. but it'd be nicer if it were simply safe.

Fortunately for me, this is only a transitive dependency via `[dev-dependencies.criterion]` and does not involve user controlled data.

Additionally, as I use a custom `RUST_TARGET_PATH`, I caught the directory traversal hack you're using and replaced it with `env!("CARGO_MANIFEST_DIR")`.