### PR TITLE
deps: bump arrayvec to 0.5

### DIFF
--- a/ci/script.sh
+++ b/ci/script.sh
@@ -4,6 +4,13 @@ set -ex
 
 cargo build --verbose
 cargo doc --verbose
+
+# Our dev dependencies want newer versions of Rust. Instead of bumping our
+# MSRV, we just don't test on our MSRV.
+if [ "$TRAVIS_RUST_VERSION" = "1.33.0" ]; then
+  exit 0
+fi
+
 cargo test --verbose
 cargo test --verbose --manifest-path csv-core/Cargo.toml
 cargo test --verbose --manifest-path csv-index/Cargo.toml

--- a/csv-core/Cargo.toml
+++ b/csv-core/Cargo.toml
@@ -28,4 +28,4 @@ libc = ["memchr/libc"]
 memchr = { version = "2", default-features = false }
 
 [dev-dependencies]
-arrayvec = { version = "0.4", default-features = false }
+arrayvec = { version = "0.5", default-features = false }


### PR DESCRIPTION
And also, don't run tests in CI on our MSRV since arrayvec has a higher
MSRV.

Closes #182