### PR TITLE
Fix documentation of Writer::delimiter

### DIFF
--- a/csv-core/src/writer.rs
+++ b/csv-core/src/writer.rs
@@ -313,7 +313,8 @@ impl Writer {
     /// a field delimiter, then nothing is written to `output`
     /// and `WriteResult::OutputFull` is returned. Otherwise,
     /// `WriteResult::InputEmpty` is returned along with the number of bytes
-    /// written to `output` (which is always `1`).
+    /// written to `output` (which is `1` in case of an unquoted
+    /// field, or `2` in case of an end quote and a field separator).
     pub fn delimiter(
         &mut self,
         mut output: &mut [u8],


### PR DESCRIPTION
I have a debug assertion about the output of `delimiter` being always 1, and I was surprised when this wasn't the case. After looking at the code, it seems that the documentation itself was wrong; it uses one byte to end the quotation and another byte to insert the delimiter, so the maximum output length is not 1, but 2.

Of course, it would be even better if there were a test case to catch this. I happened to catch this with the following CSV:
```
id,name,date,birthday
4,taro,0000/02/13,2020/02/13
5,hoge,2020/02/13,2020/02/13
9999,taro,2020/02/13,2020/02/13
3,taro,2020/bb/13,2020/02/13
98,piyo,2020/02/13,2020/02/13
-1,taro,2020/02/13,2020/02/13
9999,taro,2020/02/13,2020/02/13
5555555555555555555555555555554567898765435678ghdxk jepyfghbx kjeupyf
ghmb jidhm





a,taro,2020/02/13,2020/02/13
"test,,,,,,,,,ID","TA
RO",0010/99/a,0010/99/a
```