### PR TITLE
Use bytes when possible

### DIFF
--- a/src/deserializer.rs
+++ b/src/deserializer.rs
@@ -558,7 +558,7 @@ impl<'a, 'de: 'a, T: DeRecord<'de>> Deserializer<'de>
         // Read and drop the next field.
         // This code is reached, e.g., when trying to deserialize a header
         // that doesn't exist in the destination struct.
-        let _ = self.next_field()?;
+        let _ = self.next_field_bytes()?;
         visitor.visit_unit()
     }
 }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1879,8 +1879,8 @@ impl ReaderState {
 /// refers to the type that this iterator will deserialize a record into.
 pub struct DeserializeRecordsIntoIter<R, D> {
     rdr: Reader<R>,
-    rec: StringRecord,
-    headers: Option<StringRecord>,
+    rec: ByteRecord,
+    headers: Option<ByteRecord>,
     _priv: PhantomData<D>,
 }
 
@@ -1893,8 +1893,8 @@ impl<R: io::Read, D: DeserializeOwned> DeserializeRecordsIntoIter<R, D> {
         };
         DeserializeRecordsIntoIter {
             rdr: rdr,
-            rec: StringRecord::new(),
-            headers: headers,
+            rec: ByteRecord::new(),
+            headers: headers.map(|headers| headers.into_byte_record()),
             _priv: PhantomData,
         }
     }
@@ -1921,7 +1921,7 @@ impl<R: io::Read, D: DeserializeOwned> Iterator
     type Item = Result<D>;
 
     fn next(&mut self) -> Option<Result<D>> {
-        match self.rdr.read_record(&mut self.rec) {
+        match self.rdr.read_byte_record(&mut self.rec) {
             Err(err) => Some(Err(err)),
             Ok(false) => None,
             Ok(true) => Some(self.rec.deserialize(self.headers.as_ref())),
@@ -1937,8 +1937,8 @@ impl<R: io::Read, D: DeserializeOwned> Iterator
 /// record into.
 pub struct DeserializeRecordsIter<'r, R: 'r, D> {
     rdr: &'r mut Reader<R>,
-    rec: StringRecord,
-    headers: Option<StringRecord>,
+    rec: ByteRecord,
+    headers: Option<ByteRecord>,
     _priv: PhantomData<D>,
 }
 
@@ -1951,8 +1951,8 @@ impl<'r, R: io::Read, D: DeserializeOwned> DeserializeRecordsIter<'r, R, D> {
         };
         DeserializeRecordsIter {
             rdr: rdr,
-            rec: StringRecord::new(),
-            headers: headers,
+            rec: ByteRecord::new(),
+            headers: headers.map(|headers| headers.into_byte_record()),
             _priv: PhantomData,
         }
     }
@@ -1974,7 +1974,7 @@ impl<'r, R: io::Read, D: DeserializeOwned> Iterator
     type Item = Result<D>;
 
     fn next(&mut self) -> Option<Result<D>> {
-        match self.rdr.read_record(&mut self.rec) {
+        match self.rdr.read_byte_record(&mut self.rec) {
             Err(err) => Some(Err(err)),
             Ok(false) => None,
             Ok(true) => Some(self.rec.deserialize(self.headers.as_ref())),


### PR DESCRIPTION
The csv crate has the ability to work with records as strings or as bytes and in many places allows mixing valid and invalid Utf-8 in one record, which is great. Unfortunately, when using the `DeserializeRecordsIntoIter`/`DeserializeRecordsIter` interface to deserialize types using serde, it always required that all fields are valid Utf-8 strings.

This PR modifies `DeserializeRecordsIntoIter`/`DeserializeRecordsIter` to use `ByteRecord` internally and only convert to string when the `Deserializer` asks for it. So fields that are skipped or are deserialized using `deserialize_bytes`/`deserialize_byte_buf` do not have to be valid Utf-8 strings.

I did not benchmark, but this may also improve performance, since only the fields that are used are tested. Possible step further would be to use something like the `atoi` crate to parse numbers directly from byte slices.