### PR TITLE
Do not convert to string when skipping unused fields.

### DIFF
--- a/src/deserializer.rs
+++ b/src/deserializer.rs
@@ -558,7 +558,7 @@ impl<'a, 'de: 'a, T: DeRecord<'de>> Deserializer<'de>
         // Read and drop the next field.
         // This code is reached, e.g., when trying to deserialize a header
         // that doesn't exist in the destination struct.
-        let _ = self.next_field()?;
+        let _ = self.next_field_bytes()?;
         visitor.visit_unit()
     }
 }


### PR DESCRIPTION
Hi. This is reopening of #198, but with just one of the two commits. Turns out that this is still needed for the suggested solution to work.

If some fields are not required by serde, the `ByteRecord::deserialize` will attempt to skip them by calling `next_field`, which will fail if the skipped field is not valid utf-8. So instead lets skip unused fields using `next_field_bytes`. This affects also `StringRecord::deserialize`, but getting byte slice from string should have no cost. I didn't see any changes in the included benchmarks.