### PR TITLE
Implement Clone for ByteRecordIter and StringRecordIter

### DIFF
--- a/src/byte_record.rs
+++ b/src/byte_record.rs
@@ -761,6 +761,7 @@ impl<T: AsRef<[u8]>> Extend<T> for ByteRecord {
 ///
 /// The `'r` lifetime variable refers to the lifetime of the `ByteRecord` that
 /// is being iterated over.
+#[derive(Clone)]
 pub struct ByteRecordIter<'r> {
     /// The record we are iterating over.
     r: &'r ByteRecord,

--- a/src/string_record.rs
+++ b/src/string_record.rs
@@ -699,6 +699,7 @@ impl<'a> IntoIterator for &'a StringRecord {
 ///
 /// The `'r` lifetime variable refers to the lifetime of the `StringRecord`
 /// that is being iterated over.
+#[derive(Clone)]
 pub struct StringRecordIter<'r>(ByteRecordIter<'r>);
 
 impl<'r> Iterator for StringRecordIter<'r> {


### PR DESCRIPTION
@BurntSushi what do you think about this? I figured since the diff was so small it'd be easier to discuss over a PR than an issue.

Cloneable iterators are useful when writing code that is generic over
iterators that needs to be able to iterate twice.