### PR TITLE
Add Fuzzing script

### DIFF
--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,4 @@
+
+target
+corpus
+artifacts

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,27 @@
+
+[package]
+name = "csv-fuzz"
+version = "0.0.0"
+authors = ["Muhammad Aldo Firmansyah <m.aldofirmansyah@gmail.com>"]
+publish = false
+edition = "2020"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.3"
+csv = "1.1"
+
+[dependencies.csv]
+path = ".."
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[[bin]]
+name = "fuzz_csv"
+path = "fuzz_targets/fuzz_csv.rs"
+test = false
+doc = false

--- a/fuzz/fuzz_targets/fuzz_csv.rs
+++ b/fuzz/fuzz_targets/fuzz_csv.rs
@@ -1,0 +1,7 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+use csv::Reader;
+
+fuzz_target!(|data: &[u8]| {
+    let mut rdr = Reader::from_reader(data);
+});


### PR DESCRIPTION
This PR is to add fuzzing support, and I want to integrate into [OSS-Fuzz](https://github.com/google/oss-fuzz). This is a free service by Google where they perform continuous fuzzing of open-source projects used by industry and with the only expectation that maintainers of the project will patch the bugs found by OSS-Fuzz.

If you are interested in this, could you please provide me with an email address that will be receiving the bug reports that OSS-Fuzz find?