### PR TITLE
Add support for `#[serde(flatten)]`

### DIFF
--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -205,12 +205,7 @@ impl<'a, 'w, W: io::Write> Serializer for &'a mut SeRecord<'w, W> {
         self,
         _len: Option<usize>,
     ) -> Result<Self::SerializeMap, Self::Error> {
-        // The right behavior for serializing maps isn't clear.
-        Err(Error::custom(
-            "serializing maps is not supported, \
-             if you have a use case, please file an issue at \
-             https://github.com/BurntSushi/rust-csv",
-        ))
+        Ok(self)
     }
 
     fn serialize_struct(
@@ -300,22 +295,34 @@ impl<'a, 'w, W: io::Write> SerializeMap for &'a mut SeRecord<'w, W> {
     type Ok = ();
     type Error = Error;
 
+    fn serialize_entry<K, V>(
+        &mut self,
+        _key: &K,
+        value: &V,
+    ) -> Result<(), Self::Error>
+    where
+        K: ?Sized + Serialize,
+        V: ?Sized + Serialize,
+    {
+        value.serialize(&mut **self)
+    }
+
     fn serialize_key<T: ?Sized + Serialize>(
         &mut self,
         _key: &T,
     ) -> Result<(), Self::Error> {
-        unreachable!()
+        Ok(())
     }
 
     fn serialize_value<T: ?Sized + Serialize>(
         &mut self,
         _value: &T,
     ) -> Result<(), Self::Error> {
-        unreachable!()
+        Ok(())
     }
 
     fn end(self) -> Result<Self::Ok, Self::Error> {
-        unreachable!()
+        Ok(())
     }
 }
 
@@ -655,12 +662,7 @@ impl<'a, 'w, W: io::Write> Serializer for &'a mut SeHeader<'w, W> {
         self,
         _len: Option<usize>,
     ) -> Result<Self::SerializeMap, Self::Error> {
-        // The right behavior for serializing maps isn't clear.
-        Err(Error::custom(
-            "serializing maps is not supported, \
-             if you have a use case, please file an issue at \
-             https://github.com/BurntSushi/rust-csv",
-        ))
+        Ok(self)
     }
 
     fn serialize_struct(
@@ -750,22 +752,51 @@ impl<'a, 'w, W: io::Write> SerializeMap for &'a mut SeHeader<'w, W> {
     type Ok = ();
     type Error = Error;
 
+    fn serialize_entry<K, V>(
+        &mut self,
+        key: &K,
+        value: &V,
+    ) -> Result<(), Self::Error>
+    where
+        K: ?Sized + Serialize,
+        V: ?Sized + Serialize,
+    {
+        // Grab old state and update state to `EncounteredStructField`.
+        let old_state =
+            mem::replace(&mut self.state, HeaderState::EncounteredStructField);
+        if let HeaderState::ErrorIfWrite(err) = old_state {
+            return Err(err);
+        }
+
+        let mut serializer = SeRecord {
+            wtr: self.wtr,
+        };
+        key.serialize(&mut serializer)?;
+
+        // Check that there aren't any containers in the value.
+        self.state = HeaderState::InStructField;
+        value.serialize(&mut **self)?;
+        self.state = HeaderState::EncounteredStructField;
+
+        Ok(())
+    }
+
     fn serialize_key<T: ?Sized + Serialize>(
         &mut self,
         _key: &T,
     ) -> Result<(), Self::Error> {
-        unreachable!()
+        Ok(())
     }
 
     fn serialize_value<T: ?Sized + Serialize>(
         &mut self,
         _value: &T,
     ) -> Result<(), Self::Error> {
-        unreachable!()
+        Ok(())
     }
 
     fn end(self) -> Result<Self::Ok, Self::Error> {
-        unreachable!()
+        Ok(())
     }
 }
 
@@ -1337,5 +1368,51 @@ mod tests {
         let (wrote, got) = serialize_header(row.clone());
         assert!(wrote);
         assert_eq!(got, "label,num,label2,value,empty,label,num");
+    }
+
+    #[test]
+    fn struct_nested() {
+        #[derive(Clone, Serialize)]
+        struct Inner {
+            inner_a: i32,
+            inner_b: i32,
+        }
+
+        #[derive(Clone, Serialize)]
+        struct Middle {
+            #[serde(flatten)]
+            inner: Inner,
+            middle_a: i32,
+            middle_b: i32,
+        }
+
+        #[derive(Clone, Serialize)]
+        struct Outer {
+            // arbitrary structure nesting.
+            #[serde(flatten)]
+            middle: Middle,
+            outer_a: i32,
+            outer_b: i32,
+        }
+
+        let outer = Outer {
+            middle: Middle {
+                inner: Inner {
+                    inner_a: 0,
+                    inner_b: 1
+                },
+                middle_a: 2,
+                middle_b: 3,
+            },
+            outer_a: 4,
+            outer_b: 5,
+        };
+
+        let (wrote, got) = serialize_header(outer.clone());
+        assert!(wrote);
+        assert_eq!(got, "inner_a,inner_b,middle_a,middle_b,outer_a,outer_b");
+
+        let got = serialize(outer);
+        assert_eq!(got, "0,1,2,3,4,5\n");
     }
 }


### PR DESCRIPTION
Hi!

We have a use case for serializing maps using your library.

Consider the following structure:

```Rust
struct Inner {
    inner_a: i32,
    inner_b: i32,
}

struct Middle {
    #[serde(flatten)]
    inner: Inner,
    middle_a: i32,
    middle_b: i32,
}

struct Outer {
    #[serde(flatten)]
    middle: Middle,
    outer_a: i32,
    outer_b: i32,
}
```
initialized as
```Rust
let outer = Outer {
    middle: Middle {
        inner: Inner {
            inner_a: 0,
            inner_b: 1,
        },
        middle_a: 2,
        middle_b: 3,
    },
    outer_a: 4,
    outer_b: 5,
};
```
The expected serialized data is
```
inner_a,inner_b,middle_a,middle_b,outer_a,outer_b
0,1,2,3,4,5
```
I.e. a completely flat structure. There is no limit to the depth/width or anything else using the current solution. This particular example is added as a unit test in the PR.
Additionally, serialization inside the "flattened" structures works as expected - for example, we can achieve the desired behavior mentioned in https://github.com/BurntSushi/rust-csv/pull/197#issuecomment-741645650.
We also avoid the workaround mentioned in https://github.com/BurntSushi/rust-csv/issues/98#issuecomment-439733007, as it is very tedious, especially if the structure is big and/or deep.

Serializing fields which are `HashMap`s will still lead to a runtime error, however serializing `HashMap`s which are marked by `#[serde(flatten)]` will result in a flat structure.

If there is any room for improvement and/or changes that are needed to be done -- please let me know, I'll be happy to update the PR.