### PR TITLE
Remove /examples/data from being included in published cargo package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 keywords = ["csv", "comma", "parser", "delimited", "serde"]
 license = "Unlicense/MIT"
 categories = ["encoding", "parser-implementations"]
-exclude = ["/.travis.yml", "/appveyor.yml", "/ci/*", "/scripts/*"]
+exclude = ["/examples/data/", "/.travis.yml", "/appveyor.yml", "/ci/*", "/scripts/*"]
 edition = "2018"
 
 [badges]


### PR DESCRIPTION
The /examples directory got published on crates.io, which led to me having 2.48 megabytes of NFL plays in my ~/.cargo directory. While it's certainly interesting to know that O.Daniels managed to do a 14-yard touchdown in 2012, I don't think it's wise to include this info in every copy of rust-csv.

Usually if you want to run examples, you'd just look / clone directly from GitHub, but there's no need to publish example data to crates.io