### PR TITLE
doc: A note about internally-tagged enums not supported

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,6 +145,12 @@ $ cd rust-csv
 $ cargo run --example cookbook-read-serde < examples/data/smallpop.csv
 ```
 
+## Internally-tagged enums
+
+It should be noted that Serde's [internally-tagged enums] [can not] be deserialized by this crate.
+
+[internally-tagged enums]: https://serde.rs/enum-representations.html#internally-tagged
+[can not]: https://github.com/BurntSushi/rust-csv/issues/211
 */
 
 #![deny(missing_docs)]


### PR DESCRIPTION
Internally-tagged enums are extremely useful and therefore used quite a lot in the wild. It's a bit of a shock to users to learn (the hard way) that they're not supported by `csv`. So it'd be great to at least document this limitation in the docs.