### PR TITLE
Trim the first row in case we don't have headers

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1612,7 +1612,9 @@ impl<R: io::Read> Reader<R> {
                 }
                 return result;
             }
-        } else if self.state.trim.should_trim_fields() {
+        }
+        // It should be a record, since we have no headers, trim if necessary
+        if !self.state.has_headers && self.state.trim.should_trim_fields() {
             record.trim();
         }
         Ok(ok)


### PR DESCRIPTION
When user indicates that no headers are available, then the trim doesn't work very well for the first row
```rust
#[derive(serde::Deserialize, Debug)]
struct TestStruct {
    col1: String,
    col2: String,
    col3: String,
}

fn test() {
    let mut csv = String::from("a1, b1, c1\n");
    csv.push_str("a2, b2, c2\n");
    csv.push_str("a3, b3, c3\n");


    let mut csv_reader = ReaderBuilder::new()
    .trim(Trim::All)
    .has_headers(false)
    .flexible(true)
    .from_reader(BufReader::new(csv.as_bytes()));

    // Read as byte records, that should improve the performance without a lot of reallocations
    let mut raw_record = csv::ByteRecord::new();
    let headers = csv::ByteRecord::from(vec!["col1", "col2", "col3"]);

    while csv_reader.read_byte_record(&mut raw_record).unwrap() {
        let record = raw_record.deserialize::<TestStruct>(Some(&headers));
        println!("{:?}", record);
    }
}
```

Note that the first row is not trimmed properly.
```
Ok(TestStruct { col1: "a1", col2: " b1", col3: " c1" })
Ok(TestStruct { col1: "a2", col2: "b2", col3: "c2" })
Ok(TestStruct { col1: "a3", col2: "b3", col3: "c3" })
```

With the fix we should trim the fields like this:
```
Ok(TestStruct { col1: "a1", col2: "b1", col3: "c1" })
Ok(TestStruct { col1: "a2", col2: "b2", col3: "c2" })
Ok(TestStruct { col1: "a3", col2: "b3", col3: "c3" })
```



