### PR TITLE
Add slightly more detail about StringRecord in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,11 @@ fn example() -> Result<(), Box<dyn Error>> {
         // The iterator yields Result<StringRecord, Error>, so we check the
         // error here.
         let record = result?;
-        println!("{:?}", record);
+
+        // Records can be indexed like a vector to return single strings
+        let cell: &str = &record[0];
+
+        println!("The first cell is {:?}", cell);
     }
     Ok(())
 }

--- a/examples/cookbook-read-basic.rs
+++ b/examples/cookbook-read-basic.rs
@@ -7,9 +7,13 @@ fn example() -> Result<(), Box<dyn Error>> {
     let mut rdr = csv::Reader::from_reader(io::stdin());
     for result in rdr.records() {
         // The iterator yields Result<StringRecord, Error>, so we check the
-        // error here..
+        // error here.
         let record = result?;
-        println!("{:?}", record);
+
+        // Records can be indexed like a vector to return single strings
+        let cell: &str = &record[0];
+
+        println!("The first cell is {:?}", cell);
     }
     Ok(())
 }

--- a/src/cookbook.rs
+++ b/src/cookbook.rs
@@ -40,9 +40,13 @@ fn example() -> Result<(), Box<dyn Error>> {
     let mut rdr = csv::Reader::from_reader(io::stdin());
     for result in rdr.records() {
         // The iterator yields Result<StringRecord, Error>, so we check the
-        // error here..
+        // error here.
         let record = result?;
-        println!("{:?}", record);
+
+        // Records can be indexed like a vector to return single strings
+        let cell: &str = &record[0];
+
+        println!("The first cell is {:?}", cell);
     }
     Ok(())
 }
@@ -54,6 +58,8 @@ fn main() {
     }
 }
 ```
+
+For more information on how to use a `StringRecord` object, refer its [API page](../struct.StringRecord.html).
 
 The above example can be run like so:
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,11 @@ fn example() -> Result<(), Box<dyn Error>> {
         // The iterator yields Result<StringRecord, Error>, so we check the
         // error here.
         let record = result?;
-        println!("{:?}", record);
+
+        // Records can be indexed like a vector to return single strings
+        let cell: &str = &record[0];
+
+        println!("The first cell is {:?}", cell);
     }
     Ok(())
 }


### PR DESCRIPTION
Closes #241.

One concern I have after looking at the code is how much duplication there is wrt the examples. This one example seems to have been in `src/lib.rs`, `README.md`, and also `src/cookbook.rs`. There's that neat script for pulling out the examples into files, but that doesn't help with these 3 cases. I wonder if the new `#[doc(include="foo")]` will help here?