### PR TITLE
add GitHub Actions workflow to run tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,50 @@
+name: Rust
+
+on: [ push, pull_request ]
+
+jobs:
+  rust:
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        toolchain: [
+          1.40.0,
+          stable,
+          beta,
+          nightly
+        ]
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install Rust toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+          toolchain: ${{ matrix.toolchain }}
+          profile: minimal
+          override: true
+    - name: Toolchain version
+      run: |
+        cargo -vV
+        rustc -vV
+    - name: Run CI script
+      run: |
+        cargo build --verbose
+        cargo doc --verbose
+        # Our dev dependencies want newer versions of Rust. Instead of bumping our
+        # MSRV, we just don't test on our MSRV.
+        if [ "${{ matrix.toolchain }}" = "1.40.0" ]; then
+          exit 0
+        fi
+
+        cargo test --verbose
+        cargo test --verbose --manifest-path csv-core/Cargo.toml
+        cargo test --verbose --manifest-path csv-index/Cargo.toml
+        if [ "${{ matrix.toolchain }}" = "stable" ]; then
+          rustup component add rustfmt
+          cargo fmt -- --check
+
+          ci/check-copy cookbook
+          ci/check-copy tutorial
+        fi
+        if [ "${{ matrix.toolchain }}" = "nightly" ]; then
+          cargo bench --verbose --no-run
+        fi


### PR DESCRIPTION
This can serve as a replacement for the ceased Travis CI builds.

The builds look like this when they are successful: https://github.com/striezel-stash/rust-csv/actions/runs/1641474135

The script part of the GitHub Actions workflow is basically the [`ci/script.sh`](https://github.com/BurntSushi/rust-csv/blob/9f5455bc6a1ffcbfd7ac993dd87e023dd29cb415/ci/script.sh) ported to workflow syntax.

**Unfortunately I had to bump the MSRV build from rustc 1.33.0 to rustc 1.40.0** in the process, because rustc 1.39 and earlier failed to build. I am not sure whether this is due to some error on my part or due to some months without MSRV 1.33.0 builds where some dependencies or Rust features may have slipped into the code. However, the last Travis CI build with rustc 1.33.0 also failed ([see here](https://travis-ci.org/github/BurntSushi/rust-csv/jobs/774578336)), so I assume it is the later one and 1.40.0 is now the actual MSRV of the csv crate.