### PR TITLE
Bump to edition-2021 of Rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["csv", "comma", "parser", "delimited", "serde"]
 license = "Unlicense/MIT"
 categories = ["encoding", "parser-implementations"]
 exclude = ["/.travis.yml", "/appveyor.yml", "/ci/*", "/scripts/*"]
-edition = "2018"
+edition = "2021"
 
 [badges]
 travis-ci = { repository = "BurntSushi/rust-csv" }


### PR DESCRIPTION
This has the merit of using the new Cargo resolver, which means we don't pull serde-derive by default, which means the project compiles faster.

Free performance boost. It's like C++11 all over again :smile: 