### PR TITLE
Automatically escape fields that contain the comment character

### DIFF
--- a/csv-core/src/writer.rs
+++ b/csv-core/src/writer.rs
@@ -1065,4 +1065,21 @@ mod tests {
         inp = &inp[1..];
         assert_quote!(inp, out, 1, 2, InputEmpty, r#""""#);
     }
+
+    #[test]
+    fn comment_char_is_automatically_quoted() {
+        let mut wtr = WriterBuilder::new().comment(Some(b'#')).build();
+        let out = &mut [0; 1024];
+
+        assert_field!(
+            wtr,
+            b("# abc"),
+            &mut out[..],
+            5,
+            6,
+            InputEmpty,
+            "\"# abc"
+        );
+        assert_write!(wtr, finish, &mut out[..], 1, InputEmpty, "\"");
+    }
 }

--- a/csv-core/src/writer.rs
+++ b/csv-core/src/writer.rs
@@ -26,6 +26,7 @@ impl WriterBuilder {
             quote: b'"',
             escape: b'\\',
             double_quote: true,
+            comment: None,
         };
         WriterBuilder { wtr: wtr }
     }
@@ -55,6 +56,13 @@ impl WriterBuilder {
                 wtr.requires_quotes[b as usize] = true;
             }
             _ => unreachable!(),
+        }
+        // If the first field of a row starts with a comment character,
+        // it needs to be quoted, or the row will not be readable later.
+        // As requires_quotes is calculated in advance, we force quotes
+        // when a comment character is encountered anywhere in the field.
+        if let Some(comment) = self.wtr.comment {
+            wtr.requires_quotes[comment as usize] = true;
         }
         wtr
     }
@@ -119,6 +127,17 @@ impl WriterBuilder {
         self.wtr.double_quote = yes;
         self
     }
+
+    /// The comment character that will be used when later reading the file.
+    ///
+    /// If `quote_style` is set to `QuoteStyle::Necessary`, a field will
+    /// be quoted if the comment character is detected anywhere in the field.
+    ///
+    /// The default value is None.
+    pub fn comment(&mut self, comment: Option<u8>) -> &mut WriterBuilder {
+        self.wtr.comment = comment;
+        self
+    }
 }
 
 impl Default for WriterBuilder {
@@ -166,6 +185,7 @@ pub struct Writer {
     quote: u8,
     escape: u8,
     double_quote: bool,
+    comment: Option<u8>,
 }
 
 impl Clone for Writer {
@@ -183,6 +203,7 @@ impl Clone for Writer {
             quote: self.quote,
             escape: self.escape,
             double_quote: self.double_quote,
+            comment: self.comment,
         }
     }
 }

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -476,6 +476,17 @@ impl WriterBuilder {
         self.capacity = capacity;
         self
     }
+
+    /// The comment character that will be used when later reading the file.
+    ///
+    /// If `quote_style` is set to `QuoteStyle::Necessary`, a field will
+    /// be quoted if the comment character is detected anywhere in the field.
+    ///
+    /// The default value is None.
+    pub fn comment(&mut self, comment: Option<u8>) -> &mut WriterBuilder {
+        self.builder.comment(comment);
+        self
+    }
 }
 
 /// An already configured CSV writer.

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -493,7 +493,6 @@ impl WriterBuilder {
     ///     Ok(())
     /// }
     /// ```
-
     pub fn comment(&mut self, comment: Option<u8>) -> &mut WriterBuilder {
         self.builder.comment(comment);
         self

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -470,21 +470,39 @@ impl WriterBuilder {
         self
     }
 
-    /// Set the capacity (in bytes) of the internal buffer used in the CSV
-    /// writer. This defaults to a reasonable setting.
-    pub fn buffer_capacity(&mut self, capacity: usize) -> &mut WriterBuilder {
-        self.capacity = capacity;
-        self
-    }
-
     /// The comment character that will be used when later reading the file.
     ///
     /// If `quote_style` is set to `QuoteStyle::Necessary`, a field will
     /// be quoted if the comment character is detected anywhere in the field.
     ///
     /// The default value is None.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use std::error::Error;
+    /// use csv::WriterBuilder;
+    ///
+    /// # fn main() { example().unwrap(); }
+    /// fn example() -> Result<(), Box<dyn Error>> {
+    ///     let mut wtr =
+    ///         WriterBuilder::new().comment(Some(b'#')).from_writer(Vec::new());
+    ///     wtr.write_record(&["# comment", "another"]).unwrap();
+    ///     let buf = wtr.into_inner().unwrap();
+    ///     assert_eq!(String::from_utf8(buf).unwrap(), "\"# comment\",another\n");
+    ///     Ok(())
+    /// }
+    /// ```
+
     pub fn comment(&mut self, comment: Option<u8>) -> &mut WriterBuilder {
         self.builder.comment(comment);
+        self
+    }
+
+    /// Set the capacity (in bytes) of the internal buffer used in the CSV
+    /// writer. This defaults to a reasonable setting.
+    pub fn buffer_capacity(&mut self, capacity: usize) -> &mut WriterBuilder {
+        self.capacity = capacity;
         self
     }
 }
@@ -1422,5 +1440,14 @@ mod tests {
         let mut wtr = WriterBuilder::new().from_writer(vec![]);
         wtr.serialize((true, 1.3, "hi")).unwrap();
         assert_eq!(wtr_as_string(wtr), "true,1.3,hi\n");
+    }
+
+    #[test]
+    fn comment_char_is_automatically_quoted() {
+        let mut wtr =
+            WriterBuilder::new().comment(Some(b'#')).from_writer(Vec::new());
+        wtr.write_record(&["# comment", "another"]).unwrap();
+        let buf = wtr.into_inner().unwrap();
+        assert_eq!(String::from_utf8(buf).unwrap(), "\"# comment\",another\n");
     }
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -357,6 +357,15 @@ fn no_infinite_loop_on_io_errors() {
     assert!(record_results.next().is_none());
 }
 
+#[test]
+fn comment_char_is_automatically_quoted() {
+    let mut wtr =
+        csv::WriterBuilder::new().comment(Some(b'#')).from_writer(Vec::new());
+    wtr.write_record(&["# comment", "another"]).unwrap();
+    let buf = wtr.into_inner().unwrap();
+    assert_eq!(String::from_utf8(buf).unwrap(), "\"# comment\",another\n");
+}
+
 // Helper functions follow.
 
 /// Return the target/debug directory path.

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -357,15 +357,6 @@ fn no_infinite_loop_on_io_errors() {
     assert!(record_results.next().is_none());
 }
 
-#[test]
-fn comment_char_is_automatically_quoted() {
-    let mut wtr =
-        csv::WriterBuilder::new().comment(Some(b'#')).from_writer(Vec::new());
-    wtr.write_record(&["# comment", "another"]).unwrap();
-    let buf = wtr.into_inner().unwrap();
-    assert_eq!(String::from_utf8(buf).unwrap(), "\"# comment\",another\n");
-}
-
 // Helper functions follow.
 
 /// Return the target/debug directory path.


### PR DESCRIPTION
Currently, if data is written with QuoteStyle::Necessary, and the first
field of a row happens to start with a comment character, the row will be
ignored as a comment when later reading it back in.

This change adds a `comment` property to Writer, and automatically
quotes fields that have the provided comment character in them, so they
round-trip correctly.