### PR TITLE
Add support for source byte-range tracking for ByteRecord

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,7 +153,7 @@ use std::result;
 
 use serde::{Deserialize, Deserializer};
 
-pub use crate::byte_record::{ByteRecord, ByteRecordIter, Position};
+pub use crate::byte_record::{ByteRecord, ByteRecordIter, Position, Span};
 pub use crate::deserializer::{DeserializeError, DeserializeErrorKind};
 pub use crate::error::{
     Error, ErrorKind, FromUtf8Error, IntoInnerError, Result, Utf8Error,

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -7,7 +7,7 @@ use std::result;
 use csv_core::{Reader as CoreReader, ReaderBuilder as CoreReaderBuilder};
 use serde::de::DeserializeOwned;
 
-use crate::byte_record::{ByteRecord, Position};
+use crate::byte_record::{ByteRecord, Position, Span};
 use crate::error::{Error, ErrorKind, Result, Utf8Error};
 use crate::string_record::StringRecord;
 use crate::{Terminator, Trim};
@@ -1667,6 +1667,7 @@ impl<R: io::Read> Reader<R> {
                 }
                 Record => {
                     record.set_len(endlen);
+                    record.set_span(Some(Span::new(record.position().unwrap().byte(), self.state.cur_pos.byte())));
                     self.state.add_record(record)?;
                     return Ok(true);
                 }


### PR DESCRIPTION
`ByteRecord` (via `ByteRecordInner`) already exposes a `position` method to access line number, record number and byte offset of the start of the record.
This PR adds information to `ByteRecord` to track not only the byte offset of the _start_ of the record, but also its _end_, via  a `span` method returning a `Span`; this is useful to retrieve the original source bytes for a parsed record when e.g. reporting errors. 