### PR TITLE
Export record deserializer.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,7 +154,11 @@ use std::result;
 use serde::{Deserialize, Deserializer};
 
 pub use crate::byte_record::{ByteRecord, ByteRecordIter, Position};
-pub use crate::deserializer::{DeserializeError, DeserializeErrorKind};
+pub use crate::deserializer::{
+    byte_record_deserializer, string_record_deserializer,
+    ByteRecordDeserializer, DeserializeError, DeserializeErrorKind,
+    StringRecordDeserializer,
+};
 pub use crate::error::{
     Error, ErrorKind, FromUtf8Error, IntoInnerError, Result, Utf8Error,
 };


### PR DESCRIPTION
The library currently exposes deserialization API through the `Reader::deserialize` method, which returns an iterator over deserialized values.

This commit exposes the deserializer type through the public API, allowing users to create their own deserializer instances from `StringRecord`s and `ByteRecord`s.  This enables interoperability with existing code parameterized by deserializer type.  In my specific use case I convert deserializer into a trait object using `erased_serde`, which allows switching between different data formats at runtime, similar to the example here:
https://docs.rs/erased-serde/0.3.23/erased_serde/trait.Deserializer.html

Signed-off-by: Leonid Ryzhyk <ryzhyk@gmail.com>