### PR TITLE
Add IntoInnerError::into_error()

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -312,6 +312,15 @@ impl<W> IntoInnerError<W> {
         &self.err
     }
 
+    /// Consumes the [`IntoInnerError`] and returns the error which caused the
+    /// call to [`Writer::into_inner`](crate::Writer::into_inner) to fail.
+    ///
+    /// Unlike [`IntoInnerError::error`], this can be used to obtain ownership
+    /// of the underlying error.
+    pub fn into_error(self) -> io::Error {
+        self.err
+    }
+
     /// Returns the underlying writer which generated the error.
     ///
     /// The returned value can be used for error recovery, such as


### PR DESCRIPTION
Currently, for code that doesn't attempt to recover from errors but just reports the error to the caller, it's forced to return the entire `IntoInnerError`, which is very big compared to `io::Error` which is where the actual error is.

This commit adds `IntoInnerError::into_error()` method that consumes `IntoInnerError` and returns contained `io::Error`. This mirrors the API of [`std::io::IntoInnerError`](https://doc.rust-lang.org/stable/std/io/struct.IntoInnerError.html#method.into_error) in Rust stdlib, which provides such method.