### PR TITLE
Use the proper version for serde in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,11 +25,11 @@ bench = false
 csv-core = { path = "csv-core", version = "0.1.10" }
 itoa = "1"
 ryu = "1"
-serde = "1.0.55"
+serde = "1.0.67"
 
 [dev-dependencies]
 bstr = { version = "1.2.0", default-features = false, features = ["alloc", "serde"] }
-serde = { version = "1.0.55", features = ["derive"] }
+serde = { version = "1.0.67", features = ["derive"] }
 
 [profile.release]
 debug = true


### PR DESCRIPTION
# Description
If you try using `csv` in a project locked to `serde` versions between `1.0.55` and `1.0.66`, `csv` will fail to compile.

# Reason
`csv` uses the `serde_interger128` macro which wasn't introduced until `serde` version 1.0.67.

# Solution
This pull request bumped the `serde` version to 1.0.67.

