### PR TITLE
[FIX] Update README clone-and-run example console commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,10 +59,10 @@ fn main() {
 
 The above example can be run like so:
 
-```text
-$ git clone git@github.com:BurntSushi/rust-csv.git
-$ cd rust-csv
-$ cargo run --example cookbook-read-basic < examples/data/smallpop.csv
+```console
+git clone git@github.com:BurntSushi/rust-csv.git
+cd rust-csv
+cargo run --example cookbook-read-basic < examples/data/smallpop.csv
 ```
 
 ### Example with Serde

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ fn main() {
 The above example can be run like so:
 
 ```text
-$ git clone git://github.com/BurntSushi/rust-csv
+$ git clone git@github.com:BurntSushi/rust-csv.git
 $ cd rust-csv
 $ cargo run --example cookbook-read-basic < examples/data/smallpop.csv
 ```


### PR DESCRIPTION
# PR Description

This PR updates the `README.md` git clone command to use git over ssh instead of `git://` directly.
I found this issue while trying to follow along with the examples.

[GitHub turned off the unencrypted git protocol in January 2022.](https://github.blog/2021-09-01-improving-git-protocol-security-github/)

This PR also updates said commands for easy copy-pasting.