### PR TITLE
Add `Writer::get_ref`

### DIFF
--- a/src/writer.rs
+++ b/src/writer.rs
@@ -1068,6 +1068,11 @@ impl<W: io::Write> Writer<W> {
         Ok(())
     }
 
+    /// Return a reference to the underlying writer.
+    pub fn get_ref(&self) -> &W {
+        self.wtr.as_ref().unwrap()
+    }
+
     /// Flush the contents of the internal buffer and return the underlying
     /// writer.
     pub fn into_inner(


### PR DESCRIPTION
It's useful to be able to access the underlying writer without dropping `Writer`, for example, checking the position of an `std::io::Cursor`.