### PR TITLE
added NONE Terminator

### DIFF
--- a/csv-core/src/lib.rs
+++ b/csv-core/src/lib.rs
@@ -120,6 +120,9 @@ pub enum Terminator {
     CRLF,
     /// Parses the byte given as a record terminator.
     Any(u8),
+    /// Disable line terminator
+    /// This is useful when writing single line field by field with proper qoting
+    NONE,
     /// Hints that destructuring should not be exhaustive.
     ///
     /// This enum may grow additional variants, so this makes sure clients

--- a/csv-core/src/writer.rs
+++ b/csv-core/src/writer.rs
@@ -54,6 +54,9 @@ impl WriterBuilder {
             Any(b) => {
                 wtr.requires_quotes[b as usize] = true;
             }
+            NONE => {
+                wtr.requires_quotes[usize::MIN] = true;
+            }
             _ => unreachable!(),
         }
         wtr
@@ -375,6 +378,7 @@ impl Writer {
         let (res, o) = match self.term {
             Terminator::CRLF => write_pessimistic(&[b'\r', b'\n'], output),
             Terminator::Any(b) => write_pessimistic(&[b], output),
+            Terminator::NONE => write_pessimistic(&[], output),
             _ => unreachable!(),
         };
         if o == 0 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -221,6 +221,9 @@ pub enum Terminator {
     CRLF,
     /// Parses the byte given as a record terminator.
     Any(u8),
+    /// Disable line terminator
+    /// This is useful when writing single line field by field with proper qoting
+    NONE,
     /// Hints that destructuring should not be exhaustive.
     ///
     /// This enum may grow additional variants, so this makes sure clients
@@ -236,6 +239,7 @@ impl Terminator {
         match self {
             Terminator::CRLF => csv_core::Terminator::CRLF,
             Terminator::Any(b) => csv_core::Terminator::Any(b),
+            Terminator::NONE => csv_core::Terminator::NONE,
             _ => unreachable!(),
         }
     }

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -1127,6 +1127,7 @@ impl<W: io::Write> Writer<W> {
                 self.buf.writable()[0] = b;
                 self.buf.written(1);
             }
+            csv_core::Terminator::NONE => {}
             _ => unreachable!(),
         }
         self.state.fields_written = 0;
@@ -1413,5 +1414,15 @@ mod tests {
         let mut wtr = WriterBuilder::new().from_writer(vec![]);
         wtr.serialize((true, 1.3, "hi")).unwrap();
         assert_eq!(wtr_as_string(wtr), "true,1.3,hi\n");
+    }
+
+    #[test]
+    fn quoting_witout_terminator_char() {
+        let mut wtr = WriterBuilder::new()
+            .terminator(crate::Terminator::NONE)
+            .from_writer(vec![]);
+
+        wtr.write_record(&["foo \" bar"]).unwrap();
+        assert_eq!(wtr_as_string(wtr), "\"foo \"\" bar\"");
     }
 }


### PR DESCRIPTION
Would fix #331

This pull request would enable `rust-csv` to be used as a "csv line writer" with proper quoting but without appending any line terminator. 

Critique on the technical level as well as the semantically one would be highly appreciated so this may become a valuable addition.