### PR TITLE
Mutable ref

### DIFF
--- a/src/writer.rs
+++ b/src/writer.rs
@@ -1101,6 +1101,11 @@ impl<W: io::Write> Writer<W> {
         self.wtr.as_ref().unwrap()
     }
 
+    /// Return a mutable reference to the underlying writer.
+    pub fn get_mut(&mut self) -> &mut W {
+        self.wtr.as_mut().unwrap()
+    }
+
     /// Flush the contents of the internal buffer and return the underlying
     /// writer.
     pub fn into_inner(


### PR DESCRIPTION
Provides a mutable ref method of the underlying buffer so that it can be operated on. This is particularly useful when taking the bytes of the underlying buffer and writing them out in a stream. Upon writing them out, the underlying buffer can be cleared.

See https://github.com/BurntSushi/rust-csv/issues/349 for more background.