### PR TITLE
docs: typos

### DIFF
--- a/src/deserializer.rs
+++ b/src/deserializer.rs
@@ -649,7 +649,7 @@ impl<'a, 'de: 'a, T: DeRecord<'de>> MapAccess<'de>
     }
 }
 
-/// An Serde deserialization error.
+/// A Serde deserialization error.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct DeserializeError {
     field: Option<u64>,

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -632,7 +632,7 @@ impl ReaderBuilder {
     }
 }
 
-/// A already configured CSV reader.
+/// An already configured CSV reader.
 ///
 /// A CSV reader takes as input CSV data and transforms that into standard Rust
 /// values. The most flexible way to read CSV data is as a sequence of records,


### PR DESCRIPTION
This PR fixes 2 typos in the crate's documentation.