### PR TITLE
Improve Interoperability with Error Reporting Tools

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ serde = "1.0.55"
 
 [dev-dependencies]
 bstr = { version = "1.7.0", default-features = false, features = ["alloc", "serde"] }
+eyre = "~0.6.12"
 serde = { version = "1.0.55", features = ["derive"] }
 
 [profile.release]

--- a/examples/tutorial-error-05.rs
+++ b/examples/tutorial-error-05.rs
@@ -1,0 +1,18 @@
+use eyre::Result;
+use std::{io, process};
+
+fn main() {
+    if let Err(err) = run() {
+        println!("{:?}", err);
+        process::exit(1);
+    }
+}
+
+fn run() -> Result<()> {
+    let mut rdr = csv::Reader::from_reader(io::stdin());
+    for result in rdr.records() {
+        let record = result?;
+        println!("{:?}", record);
+    }
+    Ok(())
+}

--- a/examples/tutorial-perf-alloc-01.rs
+++ b/examples/tutorial-perf-alloc-01.rs
@@ -1,6 +1,7 @@
-use std::{error::Error, io, process};
+use eyre::Result;
+use std::{io, process};
 
-fn run() -> Result<u64, Box<dyn Error>> {
+fn run() -> Result<u64> {
     let mut rdr = csv::Reader::from_reader(io::stdin());
 
     let mut count = 0;
@@ -19,7 +20,7 @@ fn main() {
             println!("{}", count);
         }
         Err(err) => {
-            println!("{}", err);
+            println!("{:?}", err);
             process::exit(1);
         }
     }

--- a/examples/tutorial-perf-alloc-02.rs
+++ b/examples/tutorial-perf-alloc-02.rs
@@ -1,6 +1,7 @@
-use std::{error::Error, io, process};
+use eyre::Result;
+use std::{io, process};
 
-fn run() -> Result<u64, Box<dyn Error>> {
+fn run() -> Result<u64> {
     let mut rdr = csv::Reader::from_reader(io::stdin());
 
     let mut count = 0;
@@ -19,7 +20,7 @@ fn main() {
             println!("{}", count);
         }
         Err(err) => {
-            println!("{}", err);
+            println!("{:?}", err);
             process::exit(1);
         }
     }

--- a/examples/tutorial-perf-alloc-03.rs
+++ b/examples/tutorial-perf-alloc-03.rs
@@ -1,6 +1,7 @@
-use std::{error::Error, io, process};
+use eyre::Result;
+use std::{io, process};
 
-fn run() -> Result<u64, Box<dyn Error>> {
+fn run() -> Result<u64> {
     let mut rdr = csv::Reader::from_reader(io::stdin());
     let mut record = csv::ByteRecord::new();
 
@@ -19,7 +20,7 @@ fn main() {
             println!("{}", count);
         }
         Err(err) => {
-            println!("{}", err);
+            println!("{:?}", err);
             process::exit(1);
         }
     }

--- a/examples/tutorial-perf-core-01.rs
+++ b/examples/tutorial-perf-core-01.rs
@@ -1,3 +1,4 @@
+use eyre::Report;
 use std::io::{self, Read};
 use std::process;
 
@@ -63,7 +64,7 @@ fn main() {
     // Read the entire contents of stdin up front.
     let mut data = vec![];
     if let Err(err) = io::stdin().read_to_end(&mut data) {
-        println!("{}", err);
+        println!("{:?}", Report::from(err));
         process::exit(1);
     }
     match run(&data) {

--- a/examples/tutorial-perf-serde-01.rs
+++ b/examples/tutorial-perf-serde-01.rs
@@ -1,5 +1,6 @@
 #![allow(dead_code)]
-use std::{error::Error, io, process};
+use eyre::Result;
+use std::{io, process};
 
 use serde::Deserialize;
 
@@ -15,7 +16,7 @@ struct Record {
     longitude: f64,
 }
 
-fn run() -> Result<u64, Box<dyn Error>> {
+fn run() -> Result<u64> {
     let mut rdr = csv::Reader::from_reader(io::stdin());
 
     let mut count = 0;
@@ -34,7 +35,7 @@ fn main() {
             println!("{}", count);
         }
         Err(err) => {
-            println!("{}", err);
+            println!("{:?}", err);
             process::exit(1);
         }
     }

--- a/examples/tutorial-perf-serde-02.rs
+++ b/examples/tutorial-perf-serde-02.rs
@@ -1,6 +1,7 @@
 #![allow(dead_code)]
+use eyre::Result;
 use serde::Deserialize;
-use std::{error::Error, io, process};
+use std::{io, process};
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "PascalCase")]
@@ -14,7 +15,7 @@ struct Record<'a> {
     longitude: f64,
 }
 
-fn run() -> Result<u64, Box<dyn Error>> {
+fn run() -> Result<u64> {
     let mut rdr = csv::Reader::from_reader(io::stdin());
     let mut raw_record = csv::StringRecord::new();
     let headers = rdr.headers()?.clone();
@@ -35,7 +36,7 @@ fn main() {
             println!("{}", count);
         }
         Err(err) => {
-            println!("{}", err);
+            println!("{:?}", err);
             process::exit(1);
         }
     }

--- a/examples/tutorial-perf-serde-03.rs
+++ b/examples/tutorial-perf-serde-03.rs
@@ -1,5 +1,6 @@
 #![allow(dead_code)]
-use std::{error::Error, io, process};
+use eyre::Result;
+use std::{io, process};
 
 use serde::Deserialize;
 
@@ -15,7 +16,7 @@ struct Record<'a> {
     longitude: f64,
 }
 
-fn run() -> Result<u64, Box<dyn Error>> {
+fn run() -> Result<u64> {
     let mut rdr = csv::Reader::from_reader(io::stdin());
     let mut raw_record = csv::ByteRecord::new();
     let headers = rdr.byte_headers()?.clone();
@@ -36,7 +37,7 @@ fn main() {
             println!("{}", count);
         }
         Err(err) => {
-            println!("{}", err);
+            println!("{:?}", err);
             process::exit(1);
         }
     }

--- a/examples/tutorial-pipeline-pop-01.rs
+++ b/examples/tutorial-pipeline-pop-01.rs
@@ -1,4 +1,5 @@
-use std::{env, error::Error, io, process};
+use eyre::{eyre, Result};
+use std::{env, io, process};
 
 use serde::{Deserialize, Serialize};
 
@@ -14,11 +15,11 @@ struct Record {
     longitude: f64,
 }
 
-fn run() -> Result<(), Box<dyn Error>> {
+fn run() -> Result<()> {
     // Get the query from the positional arguments.
     // If one doesn't exist or isn't an integer, return an error.
     let minimum_pop: u64 = match env::args().nth(1) {
-        None => return Err(From::from("expected 1 argument, but got none")),
+        None => return Err(eyre!("expected 1 argument, but got none")),
         Some(arg) => arg.parse()?,
     };
 
@@ -53,7 +54,7 @@ fn run() -> Result<(), Box<dyn Error>> {
 
 fn main() {
     if let Err(err) = run() {
-        println!("{}", err);
+        println!("{:?}", err);
         process::exit(1);
     }
 }

--- a/examples/tutorial-pipeline-search-01.rs
+++ b/examples/tutorial-pipeline-search-01.rs
@@ -1,10 +1,11 @@
-use std::{env, error::Error, io, process};
+use eyre::{eyre, Result};
+use std::{env, io, process};
 
-fn run() -> Result<(), Box<dyn Error>> {
+fn run() -> Result<()> {
     // Get the query from the positional arguments.
     // If one doesn't exist, return an error.
     let query = match env::args().nth(1) {
-        None => return Err(From::from("expected 1 argument, but got none")),
+        None => return Err(eyre!("expected 1 argument, but got none")),
         Some(query) => query,
     };
 
@@ -31,7 +32,7 @@ fn run() -> Result<(), Box<dyn Error>> {
 
 fn main() {
     if let Err(err) = run() {
-        println!("{}", err);
+        println!("{:?}", err);
         process::exit(1);
     }
 }

--- a/examples/tutorial-pipeline-search-02.rs
+++ b/examples/tutorial-pipeline-search-02.rs
@@ -1,8 +1,9 @@
-use std::{env, error::Error, io, process};
+use eyre::{eyre, Result};
+use std::{env, io, process};
 
-fn run() -> Result<(), Box<dyn Error>> {
+fn run() -> Result<()> {
     let query = match env::args().nth(1) {
-        None => return Err(From::from("expected 1 argument, but got none")),
+        None => return Err(eyre!("expected 1 argument, but got none")),
         Some(query) => query,
     };
 
@@ -26,7 +27,7 @@ fn run() -> Result<(), Box<dyn Error>> {
 
 fn main() {
     if let Err(err) = run() {
-        println!("{}", err);
+        println!("{:?}", err);
         process::exit(1);
     }
 }

--- a/examples/tutorial-read-01.rs
+++ b/examples/tutorial-read-01.rs
@@ -1,6 +1,7 @@
-use std::{env, error::Error, ffi::OsString, fs::File, process};
+use eyre::{eyre, Result};
+use std::{env, ffi::OsString, fs::File, process};
 
-fn run() -> Result<(), Box<dyn Error>> {
+fn run() -> Result<()> {
     let file_path = get_first_arg()?;
     let file = File::open(file_path)?;
     let mut rdr = csv::Reader::from_reader(file);
@@ -13,16 +14,16 @@ fn run() -> Result<(), Box<dyn Error>> {
 
 /// Returns the first positional argument sent to this process. If there are no
 /// positional arguments, then this returns an error.
-fn get_first_arg() -> Result<OsString, Box<dyn Error>> {
+fn get_first_arg() -> Result<OsString> {
     match env::args_os().nth(1) {
-        None => Err(From::from("expected 1 argument, but got none")),
+        None => Err(eyre!("expected 1 argument, but got none")),
         Some(file_path) => Ok(file_path),
     }
 }
 
 fn main() {
     if let Err(err) = run() {
-        println!("{}", err);
+        println!("{:?}", err);
         process::exit(1);
     }
 }

--- a/examples/tutorial-read-delimiter-01.rs
+++ b/examples/tutorial-read-delimiter-01.rs
@@ -1,6 +1,7 @@
-use std::{error::Error, io, process};
+use eyre::Result;
+use std::{io, process};
 
-fn run() -> Result<(), Box<dyn Error>> {
+fn run() -> Result<()> {
     let mut rdr = csv::ReaderBuilder::new()
         .has_headers(false)
         .delimiter(b';')
@@ -18,7 +19,7 @@ fn run() -> Result<(), Box<dyn Error>> {
 
 fn main() {
     if let Err(err) = run() {
-        println!("{}", err);
+        println!("{:?}", err);
         process::exit(1);
     }
 }

--- a/examples/tutorial-read-headers-01.rs
+++ b/examples/tutorial-read-headers-01.rs
@@ -1,6 +1,7 @@
-use std::{error::Error, io, process};
+use eyre::Result;
+use std::{io, process};
 
-fn run() -> Result<(), Box<dyn Error>> {
+fn run() -> Result<()> {
     let mut rdr =
         csv::ReaderBuilder::new().has_headers(false).from_reader(io::stdin());
     for result in rdr.records() {
@@ -12,7 +13,7 @@ fn run() -> Result<(), Box<dyn Error>> {
 
 fn main() {
     if let Err(err) = run() {
-        println!("{}", err);
+        println!("{:?}", err);
         process::exit(1);
     }
 }

--- a/examples/tutorial-read-headers-02.rs
+++ b/examples/tutorial-read-headers-02.rs
@@ -1,6 +1,7 @@
-use std::{error::Error, io, process};
+use eyre::Result;
+use std::{io, process};
 
-fn run() -> Result<(), Box<dyn Error>> {
+fn run() -> Result<()> {
     let mut rdr = csv::Reader::from_reader(io::stdin());
     {
         // We nest this call in its own scope because of lifetimes.
@@ -20,7 +21,7 @@ fn run() -> Result<(), Box<dyn Error>> {
 
 fn main() {
     if let Err(err) = run() {
-        println!("{}", err);
+        println!("{:?}", err);
         process::exit(1);
     }
 }

--- a/examples/tutorial-read-serde-01.rs
+++ b/examples/tutorial-read-serde-01.rs
@@ -1,6 +1,7 @@
-use std::{error::Error, io, process};
+use eyre::Result;
+use std::{io, process};
 
-fn run() -> Result<(), Box<dyn Error>> {
+fn run() -> Result<()> {
     let mut rdr = csv::Reader::from_reader(io::stdin());
     for result in rdr.records() {
         let record = result?;
@@ -27,7 +28,7 @@ fn run() -> Result<(), Box<dyn Error>> {
 
 fn main() {
     if let Err(err) = run() {
-        println!("{}", err);
+        println!("{:?}", err);
         process::exit(1);
     }
 }

--- a/examples/tutorial-read-serde-02.rs
+++ b/examples/tutorial-read-serde-02.rs
@@ -1,10 +1,11 @@
-use std::{error::Error, io, process};
+use eyre::Result;
+use std::{io, process};
 
 // This introduces a type alias so that we can conveniently reference our
 // record type.
 type Record = (String, String, Option<u64>, f64, f64);
 
-fn run() -> Result<(), Box<dyn Error>> {
+fn run() -> Result<()> {
     let mut rdr = csv::Reader::from_reader(io::stdin());
     // Instead of creating an iterator with the `records` method, we create
     // an iterator with the `deserialize` method.
@@ -18,7 +19,7 @@ fn run() -> Result<(), Box<dyn Error>> {
 
 fn main() {
     if let Err(err) = run() {
-        println!("{}", err);
+        println!("{:?}", err);
         process::exit(1);
     }
 }

--- a/examples/tutorial-read-serde-03.rs
+++ b/examples/tutorial-read-serde-03.rs
@@ -1,11 +1,12 @@
+use eyre::Result;
 use std::collections::HashMap;
-use std::{error::Error, io, process};
+use std::{io, process};
 
 // This introduces a type alias so that we can conveniently reference our
 // record type.
 type Record = HashMap<String, String>;
 
-fn run() -> Result<(), Box<dyn Error>> {
+fn run() -> Result<()> {
     let mut rdr = csv::Reader::from_reader(io::stdin());
     for result in rdr.deserialize() {
         let record: Record = result?;
@@ -16,7 +17,7 @@ fn run() -> Result<(), Box<dyn Error>> {
 
 fn main() {
     if let Err(err) = run() {
-        println!("{}", err);
+        println!("{:?}", err);
         process::exit(1);
     }
 }

--- a/examples/tutorial-read-serde-04.rs
+++ b/examples/tutorial-read-serde-04.rs
@@ -1,5 +1,6 @@
 #![allow(dead_code)]
-use std::{error::Error, io, process};
+use eyre::Result;
+use std::{io, process};
 
 // This lets us write `#[derive(Deserialize)]`.
 use serde::Deserialize;
@@ -19,7 +20,7 @@ struct Record {
     state: String,
 }
 
-fn run() -> Result<(), Box<dyn Error>> {
+fn run() -> Result<()> {
     let mut rdr = csv::Reader::from_reader(io::stdin());
     for result in rdr.deserialize() {
         let record: Record = result?;
@@ -32,7 +33,7 @@ fn run() -> Result<(), Box<dyn Error>> {
 
 fn main() {
     if let Err(err) = run() {
-        println!("{}", err);
+        println!("{:?}", err);
         process::exit(1);
     }
 }

--- a/examples/tutorial-read-serde-invalid-01.rs
+++ b/examples/tutorial-read-serde-invalid-01.rs
@@ -1,5 +1,6 @@
 #![allow(dead_code)]
-use std::{error::Error, io, process};
+use eyre::Result;
+use std::{io, process};
 
 use serde::Deserialize;
 
@@ -13,7 +14,7 @@ struct Record {
     state: String,
 }
 
-fn run() -> Result<(), Box<dyn Error>> {
+fn run() -> Result<()> {
     let mut rdr = csv::Reader::from_reader(io::stdin());
     for result in rdr.deserialize() {
         let record: Record = result?;
@@ -24,7 +25,7 @@ fn run() -> Result<(), Box<dyn Error>> {
 
 fn main() {
     if let Err(err) = run() {
-        println!("{}", err);
+        println!("{:?}", err);
         process::exit(1);
     }
 }

--- a/examples/tutorial-read-serde-invalid-02.rs
+++ b/examples/tutorial-read-serde-invalid-02.rs
@@ -1,5 +1,6 @@
 #![allow(dead_code)]
-use std::{error::Error, io, process};
+use eyre::Result;
+use std::{io, process};
 
 use serde::Deserialize;
 #[derive(Debug, Deserialize)]
@@ -13,7 +14,7 @@ struct Record {
     state: String,
 }
 
-fn run() -> Result<(), Box<dyn Error>> {
+fn run() -> Result<()> {
     let mut rdr = csv::Reader::from_reader(io::stdin());
     for result in rdr.deserialize() {
         let record: Record = result?;
@@ -24,7 +25,7 @@ fn run() -> Result<(), Box<dyn Error>> {
 
 fn main() {
     if let Err(err) = run() {
-        println!("{}", err);
+        println!("{:?}", err);
         process::exit(1);
     }
 }

--- a/examples/tutorial-write-01.rs
+++ b/examples/tutorial-write-01.rs
@@ -1,6 +1,7 @@
-use std::{error::Error, io, process};
+use eyre::Result;
+use std::{io, process};
 
-fn run() -> Result<(), Box<dyn Error>> {
+fn run() -> Result<()> {
     let mut wtr = csv::Writer::from_writer(io::stdout());
     // Since we're writing records manually, we must explicitly write our
     // header record. A header record is written the same way that other
@@ -30,7 +31,7 @@ fn run() -> Result<(), Box<dyn Error>> {
 
 fn main() {
     if let Err(err) = run() {
-        println!("{}", err);
+        println!("{:?}", err);
         process::exit(1);
     }
 }

--- a/examples/tutorial-write-02.rs
+++ b/examples/tutorial-write-02.rs
@@ -1,6 +1,7 @@
-use std::{env, error::Error, ffi::OsString, process};
+use eyre::{eyre, Result};
+use std::{env, ffi::OsString, process};
 
-fn run() -> Result<(), Box<dyn Error>> {
+fn run() -> Result<()> {
     let file_path = get_first_arg()?;
     let mut wtr = csv::Writer::from_path(file_path)?;
 
@@ -27,16 +28,16 @@ fn run() -> Result<(), Box<dyn Error>> {
 
 /// Returns the first positional argument sent to this process. If there are no
 /// positional arguments, then this returns an error.
-fn get_first_arg() -> Result<OsString, Box<dyn Error>> {
+fn get_first_arg() -> Result<OsString> {
     match env::args_os().nth(1) {
-        None => Err(From::from("expected 1 argument, but got none")),
+        None => Err(eyre!("expected 1 argument, but got none")),
         Some(file_path) => Ok(file_path),
     }
 }
 
 fn main() {
     if let Err(err) = run() {
-        println!("{}", err);
+        println!("{:?}", err);
         process::exit(1);
     }
 }

--- a/examples/tutorial-write-delimiter-01.rs
+++ b/examples/tutorial-write-delimiter-01.rs
@@ -1,6 +1,7 @@
-use std::{error::Error, io, process};
+use eyre::Result;
+use std::{io, process};
 
-fn run() -> Result<(), Box<dyn Error>> {
+fn run() -> Result<()> {
     let mut wtr = csv::WriterBuilder::new()
         .delimiter(b'\t')
         .quote_style(csv::QuoteStyle::NonNumeric)
@@ -29,7 +30,7 @@ fn run() -> Result<(), Box<dyn Error>> {
 
 fn main() {
     if let Err(err) = run() {
-        println!("{}", err);
+        println!("{:?}", err);
         process::exit(1);
     }
 }

--- a/examples/tutorial-write-serde-01.rs
+++ b/examples/tutorial-write-serde-01.rs
@@ -1,6 +1,7 @@
-use std::{error::Error, io, process};
+use eyre::Result;
+use std::{io, process};
 
-fn run() -> Result<(), Box<dyn Error>> {
+fn run() -> Result<()> {
     let mut wtr = csv::Writer::from_writer(io::stdout());
 
     // We still need to write headers manually.
@@ -34,7 +35,7 @@ fn run() -> Result<(), Box<dyn Error>> {
 
 fn main() {
     if let Err(err) = run() {
-        println!("{}", err);
+        println!("{:?}", err);
         process::exit(1);
     }
 }

--- a/examples/tutorial-write-serde-02.rs
+++ b/examples/tutorial-write-serde-02.rs
@@ -1,4 +1,5 @@
-use std::{error::Error, io, process};
+use eyre::Result;
+use std::{io, process};
 
 use serde::Serialize;
 
@@ -13,7 +14,7 @@ struct Record<'a> {
     longitude: f64,
 }
 
-fn run() -> Result<(), Box<dyn Error>> {
+fn run() -> Result<()> {
     let mut wtr = csv::Writer::from_writer(io::stdout());
 
     wtr.serialize(Record {
@@ -44,7 +45,7 @@ fn run() -> Result<(), Box<dyn Error>> {
 
 fn main() {
     if let Err(err) = run() {
-        println!("{}", err);
+        println!("{:?}", err);
         process::exit(1);
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -133,24 +133,35 @@ impl From<Error> for io::Error {
     }
 }
 
-impl StdError for Error {}
+impl StdError for Error {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        match self.kind() {
+            ErrorKind::Io(err) => err.source(),
+            ErrorKind::Utf8 { err, .. } => Some(err),
+            ErrorKind::UnequalLengths { .. } => None,
+            ErrorKind::Seek => None,
+            ErrorKind::Serialize(_) => None,
+            ErrorKind::Deserialize { err, .. } => Some(err),
+            _ => unreachable!(),
+        }
+    }
+}
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self.0 {
             ErrorKind::Io(ref err) => err.fmt(f),
             ErrorKind::Utf8 { pos: None, ref err } => {
-                write!(f, "CSV parse error: field {}: {}", err.field(), err)
+                write!(f, "CSV parse error: field {}.", err.field())
             }
             ErrorKind::Utf8 { pos: Some(ref pos), ref err } => write!(
                 f,
                 "CSV parse error: record {} \
-                 (line {}, field: {}, byte: {}): {}",
+                 (line {}, field: {}, byte: {}).",
                 pos.record(),
                 pos.line(),
                 err.field(),
                 pos.byte(),
-                err
             ),
             ErrorKind::UnequalLengths { pos: None, expected_len, len } => {
                 write!(
@@ -185,17 +196,16 @@ impl fmt::Display for Error {
             ErrorKind::Serialize(ref err) => {
                 write!(f, "CSV write error: {}", err)
             }
-            ErrorKind::Deserialize { pos: None, ref err } => {
-                write!(f, "CSV deserialize error: {}", err)
+            ErrorKind::Deserialize { pos: None, .. } => {
+                write!(f, "CSV deserialize error")
             }
-            ErrorKind::Deserialize { pos: Some(ref pos), ref err } => write!(
+            ErrorKind::Deserialize { pos: Some(ref pos), .. } => write!(
                 f,
                 "CSV deserialize error: record {} \
-                 (line: {}, byte: {}): {}",
+                 (line: {}, byte: {}).",
                 pos.record(),
                 pos.line(),
                 pos.byte(),
-                err
             ),
             _ => unreachable!(),
         }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -147,6 +147,25 @@ quux,baz,foobar
 }
 
 #[test]
+fn tutorial_error_05() {
+    let mut cmd = cmd_for_example("tutorial-error-05");
+    let out = cmd_output_with(&mut cmd, USPOP.as_bytes());
+    assert_eq!(out.stdout().lines().count(), 100);
+}
+
+#[test]
+fn tutorial_error_05_errored() {
+    let data = "\
+header1,header2
+foo,bar
+quux,baz,foobar
+";
+    let mut cmd = cmd_for_example("tutorial-error-05");
+    let out = cmd_output_with(&mut cmd, data.as_bytes());
+    assert!(out.stdout_failed().contains("CSV error:"));
+}
+
+#[test]
 fn tutorial_read_01() {
     let mut cmd = cmd_for_example("tutorial-read-01");
     cmd.arg(data_dir().join("uspop.csv"));


### PR DESCRIPTION
# Introduction
I recently opened an issue (#354) thinking that there was a bug in this crate, but the problem that I was having tourned out to be caused by a bug from `serde`. While I was going through the source code of this crate I noticed a minor thing that could, at least according to my personal opinion, be improved. Given the great value that I was able to get from this library, I thought I could attempt to give a small contribution to `rust-csv` and implemented this PR.

Before describing my proposal, I'd just like to clarify that although I opened a PR, I don't think that the code I'm presenting is necessarily ready to be merged yet. I've submitted it just so that we discuss the changes while looking at something concrete. The code compiles and passes all the tests.

# Problem Description
The issue I'm having is with the way in which errors from this crate are formatted in their `Display` trait. In particular, if any `csv::Error` has a source error, it will be formatted as `"<error description>: <source description>"`. The resulting string is hard to read, especially when the error chain is long.

Chaining errors descriptions by placing them in the same string and separating them with a colon is a simple, common practice. I was doing the same until a few months ago, when I've come across [`anyhow`](https://crates.io/crates/anyhow) and [`eyre`](https://crates.io/crates/eyre). Now I use them to format my errors and the legibility of my logs has greatly improven as a consequence.

Unfortunately, `csv::Error` currently doesn't play nicely with these tools. The first reason is, of course, that it manually handles the formatting of its source. The second is that it doesn't implement `std::error::Error::source`, so that `eyre` isn't able to follow the error trace and print it.

# Proposed Solution
This PR would fix both of the issues I've just described.

- First of all, it adds an implementation for `std::error::Error::source`, which would improve the interoperability with error reporting tools I've just described. It would also allow any client code to use `std::error::Error::source` and would better model the semantics of the errors that `rust-csv` produces.

- Secondly, it changes the implementation of `Display` for `csv::Error` so that the resulting string doesn't include the source error anymore, leaving this task to `eyre` and similar libraries.

- I've also updated the tutorial so that now most of the example report their errors with `eyre`. I've done it in order to be proactive, but it's the change I'm less confident about: on one hand readers might not want to bother `eyre`, but on the other if they were to run the examples without it they wouldn't be getting a complete description of the error, which might be confusing. Moreover, one of the tests associated with the tutorial relies on the description of a nested error being present, so it would break if `eyre` were not used.

Finally, I've not added `eyre` to the cookbook, because it didn't seem worth it, but I can fix this if you prefer.