### PR TITLE
Position is actually not optional

### DIFF
--- a/csv-index/src/simple.rs
+++ b/csv-index/src/simple.rs
@@ -103,14 +103,14 @@ impl<W: io::Write> RandomAccessSimple<W> {
         if rdr.has_headers() {
             let header = rdr.byte_headers()?;
             if !header.is_empty() {
-                let pos = header.position().expect("position on header row");
+                let pos = header.position();
                 wtr.write_u64::<BigEndian>(pos.byte())?;
                 len += 1;
             }
         }
         let mut record = csv::ByteRecord::new();
         while rdr.read_byte_record(&mut record)? {
-            let pos = record.position().expect("position on row");
+            let pos = record.position();
             wtr.write_u64::<BigEndian>(pos.byte())?;
             len += 1;
         }

--- a/src/byte_record.rs
+++ b/src/byte_record.rs
@@ -88,7 +88,7 @@ impl fmt::Debug for ByteRecord {
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct ByteRecordInner {
     /// The position of this byte record.
-    pos: Option<Position>,
+    pos: Position,
     /// All fields in this record, stored contiguously.
     fields: Vec<u8>,
     /// The number of and location of each field in this record.
@@ -138,7 +138,7 @@ impl ByteRecord {
     #[inline]
     pub fn with_capacity(buffer: usize, fields: usize) -> ByteRecord {
         ByteRecord(Box::new(ByteRecordInner {
-            pos: None,
+            pos: Position::new(),
             fields: vec![0; buffer],
             bounds: Bounds::with_capacity(fields),
         }))
@@ -372,7 +372,7 @@ impl ByteRecord {
         // TODO: We could likely do this in place, but for now, we allocate.
         let mut trimmed =
             ByteRecord::with_capacity(self.as_slice().len(), self.len());
-        trimmed.set_position(self.position().cloned());
+        trimmed.set_position(self.position().clone());
         for field in self.iter() {
             trimmed.push_field(trim_ascii(field));
         }
@@ -418,7 +418,7 @@ impl ByteRecord {
     ///
     ///     assert!(rdr.read_byte_record(&mut record)?);
     ///     {
-    ///         let pos = record.position().expect("a record position");
+    ///         let pos = record.position();
     ///         assert_eq!(pos.byte(), 0);
     ///         assert_eq!(pos.line(), 1);
     ///         assert_eq!(pos.record(), 0);
@@ -426,7 +426,7 @@ impl ByteRecord {
     ///
     ///     assert!(rdr.read_byte_record(&mut record)?);
     ///     {
-    ///         let pos = record.position().expect("a record position");
+    ///         let pos = record.position();
     ///         assert_eq!(pos.byte(), 6);
     ///         assert_eq!(pos.line(), 2);
     ///         assert_eq!(pos.record(), 1);
@@ -438,8 +438,8 @@ impl ByteRecord {
     /// }
     /// ```
     #[inline]
-    pub fn position(&self) -> Option<&Position> {
-        self.0.pos.as_ref()
+    pub fn position(&self) -> &Position {
+        &self.0.pos
     }
 
     /// Set the position of this record.
@@ -455,11 +455,11 @@ impl ByteRecord {
     /// pos.set_line(4);
     /// pos.set_record(2);
     ///
-    /// record.set_position(Some(pos.clone()));
-    /// assert_eq!(record.position(), Some(&pos));
+    /// record.set_position(pos.clone());
+    /// assert_eq!(record.position(), &pos);
     /// ```
     #[inline]
-    pub fn set_position(&mut self, pos: Option<Position>) {
+    pub fn set_position(&mut self, pos: Position) {
         self.0.pos = pos;
     }
 

--- a/src/deserializer.rs
+++ b/src/deserializer.rs
@@ -29,7 +29,7 @@ pub fn deserialize_string_record<'de, D: Deserialize<'de>>(
     });
     D::deserialize(&mut deser).map_err(|err| {
         Error::new(ErrorKind::Deserialize {
-            pos: record.position().map(Clone::clone),
+            pos: record.position().clone(),
             err,
         })
     })
@@ -46,7 +46,7 @@ pub fn deserialize_byte_record<'de, D: Deserialize<'de>>(
     });
     D::deserialize(&mut deser).map_err(|err| {
         Error::new(ErrorKind::Deserialize {
-            pos: record.position().map(Clone::clone),
+            pos: record.position().clone(),
             err,
         })
     })

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1330,7 +1330,7 @@ impl<R: io::Read> Reader<R> {
         match headers.string_record {
             Ok(ref record) => Ok(record),
             Err(ref err) => Err(Error::new(ErrorKind::Utf8 {
-                pos: headers.byte_record.position().map(Clone::clone),
+                pos: headers.byte_record.position().clone(),
                 err: err.clone(),
             })),
         }
@@ -1622,7 +1622,7 @@ impl<R: io::Read> Reader<R> {
         use csv_core::ReadRecordResult::*;
 
         record.clear();
-        record.set_position(Some(self.state.cur_pos.clone()));
+        record.set_position(self.state.cur_pos.clone());
         if self.state.eof != ReaderEofState::NotEof {
             return Ok(false);
         }
@@ -1887,7 +1887,7 @@ impl ReaderState {
                 Some(expected) => {
                     if record.len() as u64 != expected {
                         return Err(Error::new(ErrorKind::UnequalLengths {
-                            pos: record.position().map(Clone::clone),
+                            pos: record.position().clone(),
                             expected_len: expected,
                             len: record.len() as u64,
                         }));
@@ -2272,7 +2272,7 @@ mod tests {
             assert_eq!(b"baz", &headers[2]);
         }
         match *rdr.headers().unwrap_err().kind() {
-            ErrorKind::Utf8 { pos: Some(ref pos), ref err } => {
+            ErrorKind::Utf8 { ref pos, ref err } => {
                 assert_eq!(pos, &newpos(0, 1, 0));
                 assert_eq!(err.field(), 1);
                 assert_eq!(err.valid_up_to(), 3);
@@ -2320,7 +2320,7 @@ mod tests {
                     ref pos,
                     len: 2,
                 } => {
-                    assert_eq!(pos, &Some(newpos(4, 2, 1)));
+                    assert_eq!(pos, &newpos(4, 2, 1));
                 }
                 ref wrong => panic!("match failed, got {:?}", wrong),
             },
@@ -2369,7 +2369,7 @@ mod tests {
                     ref pos,
                     len: 2,
                 } => {
-                    assert_eq!(pos, &Some(newpos(4, 2, 1)));
+                    assert_eq!(pos, &newpos(4, 2, 1));
                 }
                 wrong => panic!("match failed, got {:?}", wrong),
             },
@@ -2441,7 +2441,7 @@ mod tests {
             assert_eq!(b"baz", &headers[2]);
         }
         match *rdr.headers().unwrap_err().kind() {
-            ErrorKind::Utf8 { pos: Some(ref pos), ref err } => {
+            ErrorKind::Utf8 { ref pos, ref err } => {
                 assert_eq!(pos, &newpos(0, 1, 0));
                 assert_eq!(err.field(), 1);
                 assert_eq!(err.valid_up_to(), 1);
@@ -2571,12 +2571,12 @@ mod tests {
             .from_reader("a,b,c\nx,y,z".as_bytes())
             .into_records();
 
-        let pos = rdr.next().unwrap().unwrap().position().unwrap().clone();
+        let pos = rdr.next().unwrap().unwrap().position().clone();
         assert_eq!(pos.byte(), 0);
         assert_eq!(pos.line(), 1);
         assert_eq!(pos.record(), 0);
 
-        let pos = rdr.next().unwrap().unwrap().position().unwrap().clone();
+        let pos = rdr.next().unwrap().unwrap().position().clone();
         assert_eq!(pos.byte(), 6);
         assert_eq!(pos.line(), 2);
         assert_eq!(pos.record(), 1);
@@ -2590,7 +2590,7 @@ mod tests {
             .from_reader("a,b,c\nx,y,z".as_bytes())
             .into_records();
 
-        let pos = rdr.next().unwrap().unwrap().position().unwrap().clone();
+        let pos = rdr.next().unwrap().unwrap().position().clone();
         assert_eq!(pos.byte(), 6);
         assert_eq!(pos.line(), 2);
         assert_eq!(pos.record(), 1);

--- a/src/string_record.rs
+++ b/src/string_record.rs
@@ -433,7 +433,7 @@ impl StringRecord {
         // TODO: We could likely do this in place, but for now, we allocate.
         let mut trimmed =
             StringRecord::with_capacity(self.as_slice().len(), self.len());
-        trimmed.set_position(self.position().cloned());
+        trimmed.set_position(self.position().clone());
         for field in &*self {
             trimmed.push_field(field.trim());
         }
@@ -473,7 +473,7 @@ impl StringRecord {
     ///
     ///     assert!(rdr.read_record(&mut record)?);
     ///     {
-    ///         let pos = record.position().expect("a record position");
+    ///         let pos = record.position();
     ///         assert_eq!(pos.byte(), 0);
     ///         assert_eq!(pos.line(), 1);
     ///         assert_eq!(pos.record(), 0);
@@ -481,7 +481,7 @@ impl StringRecord {
     ///
     ///     assert!(rdr.read_record(&mut record)?);
     ///     {
-    ///         let pos = record.position().expect("a record position");
+    ///         let pos = record.position();
     ///         assert_eq!(pos.byte(), 6);
     ///         assert_eq!(pos.line(), 2);
     ///         assert_eq!(pos.record(), 1);
@@ -493,7 +493,7 @@ impl StringRecord {
     /// }
     /// ```
     #[inline]
-    pub fn position(&self) -> Option<&Position> {
+    pub fn position(&self) -> &Position {
         self.0.position()
     }
 
@@ -510,11 +510,11 @@ impl StringRecord {
     /// pos.set_line(4);
     /// pos.set_record(2);
     ///
-    /// record.set_position(Some(pos.clone()));
-    /// assert_eq!(record.position(), Some(&pos));
+    /// record.set_position(pos.clone());
+    /// assert_eq!(record.position(), &pos);
     /// ```
     #[inline]
-    pub fn set_position(&mut self, pos: Option<Position>) {
+    pub fn set_position(&mut self, pos: Position) {
         self.0.set_position(pos);
     }
 
@@ -645,9 +645,7 @@ impl StringRecord {
         };
         match (read_res, utf8_res) {
             (Err(err), _) => Err(err),
-            (Ok(_), Err(err)) => {
-                Err(Error::new(ErrorKind::Utf8 { pos: Some(pos), err }))
-            }
+            (Ok(_), Err(err)) => Err(Error::new(ErrorKind::Utf8 { pos, err })),
             (Ok(eof), Ok(())) => Ok(eof),
         }
     }

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -12,7 +12,7 @@ use crate::{
     byte_record::ByteRecord,
     error::{Error, ErrorKind, IntoInnerError, Result},
     serializer::{serialize, serialize_header},
-    {QuoteStyle, Terminator},
+    Position, QuoteStyle, Terminator,
 };
 
 /// Builds a CSV writer with various configuration knobs.
@@ -1170,7 +1170,7 @@ impl<W: io::Write> Writer<W> {
                 }
                 Some(expected) if expected != self.state.fields_written => {
                     return Err(Error::new(ErrorKind::UnequalLengths {
-                        pos: None,
+                        pos: Position::new(),
                         expected_len: expected,
                         len: self.state.fields_written,
                     }))
@@ -1219,7 +1219,8 @@ mod tests {
     use serde::{serde_if_integer128, Serialize};
 
     use crate::{
-        byte_record::ByteRecord, error::ErrorKind, string_record::StringRecord,
+        byte_record::ByteRecord, error::ErrorKind,
+        string_record::StringRecord, Position,
     };
 
     use super::{Writer, WriterBuilder};
@@ -1301,7 +1302,7 @@ mod tests {
         let err = wtr.write_record(&ByteRecord::from(vec!["a"])).unwrap_err();
         match *err.kind() {
             ErrorKind::UnequalLengths { ref pos, expected_len, len } => {
-                assert!(pos.is_none());
+                assert_eq!(pos, &Position::new());
                 assert_eq!(expected_len, 3);
                 assert_eq!(len, 1);
             }
@@ -1319,7 +1320,7 @@ mod tests {
             wtr.write_byte_record(&ByteRecord::from(vec!["a"])).unwrap_err();
         match *err.kind() {
             ErrorKind::UnequalLengths { ref pos, expected_len, len } => {
-                assert!(pos.is_none());
+                assert_eq!(pos, &Position::new());
                 assert_eq!(expected_len, 3);
                 assert_eq!(len, 1);
             }


### PR DESCRIPTION
Hello,

While investigating in which cases it is safe to unwrap `position` , I came to conclusion that it is actually always present.
There's exactly two places that it was None before:
* while creating `ByteRecord` - now it defaults to `Position::new()` which totally makes sense
* while returning `ErrorKind::UnequalLengths` from writer - I wrote a comment on a type, that for writer position is not tracked.

Even though it makes things easier to use and reason about (no need to unwrap anything, or handle None case that will never happen), this is however breaking change for the end user...