### PR TITLE
Fix 337: Look ahead for b' ' if skip_initial_space is enabled

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -630,6 +630,15 @@ impl ReaderBuilder {
         self.builder.nfa(yes);
         self
     }
+
+    /// Enable or disable initial space.
+    ///
+    /// When enabled skip any space following the field delimiter when
+    /// parsing CSV.
+    pub fn skip_initial_space(&mut self, yes: bool) -> &mut ReaderBuilder {
+        self.builder.skip_initial_space(yes);
+        self
+    }
 }
 
 /// A already configured CSV reader.


### PR DESCRIPTION
Fixes #337 

When we hit a delmiter, if skip_initial_space option is enabled, we look ahead for a space to ignore.