### PR TITLE
api: Use `#[non_exhaustive]` instead of `#[doc(hidden)]` variant

### DIFF
--- a/csv-core/src/lib.rs
+++ b/csv-core/src/lib.rs
@@ -115,18 +115,12 @@ mod writer;
 /// Use this to specify the record terminator while parsing CSV. The default is
 /// CRLF, which treats `\r`, `\n` or `\r\n` as a single record terminator.
 #[derive(Clone, Copy, Debug)]
+#[non_exhaustive]
 pub enum Terminator {
     /// Parses `\r`, `\n` or `\r\n` as a single record terminator.
     CRLF,
     /// Parses the byte given as a record terminator.
     Any(u8),
-    /// Hints that destructuring should not be exhaustive.
-    ///
-    /// This enum may grow additional variants, so this makes sure clients
-    /// don't count on exhaustive matching. (Otherwise, adding a new variant
-    /// could break existing code.)
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 impl Terminator {
@@ -135,7 +129,6 @@ impl Terminator {
         match *self {
             Terminator::CRLF => true,
             Terminator::Any(_) => false,
-            _ => unreachable!(),
         }
     }
 
@@ -143,7 +136,6 @@ impl Terminator {
         match *self {
             Terminator::CRLF => other == b'\r' || other == b'\n',
             Terminator::Any(b) => other == b,
-            _ => unreachable!(),
         }
     }
 }
@@ -156,6 +148,7 @@ impl Default for Terminator {
 
 /// The quoting style to use when writing CSV data.
 #[derive(Clone, Copy, Debug)]
+#[non_exhaustive]
 pub enum QuoteStyle {
     /// This puts quotes around every field. Always.
     Always,
@@ -173,13 +166,6 @@ pub enum QuoteStyle {
     NonNumeric,
     /// This *never* writes quotes, even if it would produce invalid CSV data.
     Never,
-    /// Hints that destructuring should not be exhaustive.
-    ///
-    /// This enum may grow additional variants, so this makes sure clients
-    /// don't count on exhaustive matching. (Otherwise, adding a new variant
-    /// could break existing code.)
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 impl Default for QuoteStyle {

--- a/csv-core/src/reader.rs
+++ b/csv-core/src/reader.rs
@@ -819,7 +819,6 @@ impl Reader {
                 self.dfa.classes.add(b'\r');
                 self.dfa.classes.add(b'\n');
             }
-            _ => unreachable!(),
         }
         // Build the DFA transition table by computing the DFA state for all
         // possible combinations of state and input byte.

--- a/csv-core/src/writer.rs
+++ b/csv-core/src/writer.rs
@@ -55,7 +55,6 @@ impl WriterBuilder {
             Any(b) => {
                 wtr.requires_quotes[b as usize] = true;
             }
-            _ => unreachable!(),
         }
         // If the first field of a row starts with a comment character,
         // it needs to be quoted, or the row will not be readable later.
@@ -396,7 +395,6 @@ impl Writer {
         let (res, o) = match self.term {
             Terminator::CRLF => write_pessimistic(&[b'\r', b'\n'], output),
             Terminator::Any(b) => write_pessimistic(&[b], output),
-            _ => unreachable!(),
         };
         if o == 0 {
             return (res, nout);
@@ -446,7 +444,6 @@ impl Writer {
             QuoteStyle::Never => false,
             QuoteStyle::NonNumeric => is_non_numeric(input),
             QuoteStyle::Necessary => self.needs_quotes(input),
-            _ => unreachable!(),
         }
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -57,6 +57,7 @@ impl Error {
 
 /// The specific type of an error.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum ErrorKind {
     /// An I/O error that occurred while reading CSV data.
     Io(io::Error),
@@ -97,13 +98,6 @@ pub enum ErrorKind {
         /// The deserialization error.
         err: DeserializeError,
     },
-    /// Hints that destructuring should not be exhaustive.
-    ///
-    /// This enum may grow additional variants, so this makes sure clients
-    /// don't count on exhaustive matching. (Otherwise, adding a new variant
-    /// could break existing code.)
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 impl ErrorKind {
@@ -197,7 +191,6 @@ impl fmt::Display for Error {
                 pos.byte(),
                 err
             ),
-            _ => unreachable!(),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,6 +167,7 @@ mod writer;
 
 /// The quoting style to use when writing CSV data.
 #[derive(Clone, Copy, Debug)]
+#[non_exhaustive]
 pub enum QuoteStyle {
     /// This puts quotes around every field. Always.
     Always,
@@ -184,13 +185,6 @@ pub enum QuoteStyle {
     NonNumeric,
     /// This *never* writes quotes, even if it would produce invalid CSV data.
     Never,
-    /// Hints that destructuring should not be exhaustive.
-    ///
-    /// This enum may grow additional variants, so this makes sure clients
-    /// don't count on exhaustive matching. (Otherwise, adding a new variant
-    /// could break existing code.)
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 impl QuoteStyle {
@@ -200,7 +194,6 @@ impl QuoteStyle {
             QuoteStyle::Necessary => csv_core::QuoteStyle::Necessary,
             QuoteStyle::NonNumeric => csv_core::QuoteStyle::NonNumeric,
             QuoteStyle::Never => csv_core::QuoteStyle::Never,
-            _ => unreachable!(),
         }
     }
 }
@@ -216,18 +209,12 @@ impl Default for QuoteStyle {
 /// Use this to specify the record terminator while parsing CSV. The default is
 /// CRLF, which treats `\r`, `\n` or `\r\n` as a single record terminator.
 #[derive(Clone, Copy, Debug)]
+#[non_exhaustive]
 pub enum Terminator {
     /// Parses `\r`, `\n` or `\r\n` as a single record terminator.
     CRLF,
     /// Parses the byte given as a record terminator.
     Any(u8),
-    /// Hints that destructuring should not be exhaustive.
-    ///
-    /// This enum may grow additional variants, so this makes sure clients
-    /// don't count on exhaustive matching. (Otherwise, adding a new variant
-    /// could break existing code.)
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 impl Terminator {
@@ -236,7 +223,6 @@ impl Terminator {
         match self {
             Terminator::CRLF => csv_core::Terminator::CRLF,
             Terminator::Any(b) => csv_core::Terminator::Any(b),
-            _ => unreachable!(),
         }
     }
 }
@@ -249,6 +235,7 @@ impl Default for Terminator {
 
 /// The whitespace preservation behaviour when reading CSV data.
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[non_exhaustive]
 pub enum Trim {
     /// Preserves fields and headers. This is the default.
     None,
@@ -258,13 +245,6 @@ pub enum Trim {
     Fields,
     /// Trim whitespace from fields and headers.
     All,
-    /// Hints that destructuring should not be exhaustive.
-    ///
-    /// This enum may grow additional variants, so this makes sure clients
-    /// don't count on exhaustive matching. (Otherwise, adding a new variant
-    /// could break existing code.)
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 impl Trim {


### PR DESCRIPTION
This was introduced in Rust 1.40, which is below the MSRV of 1.73.

It technically breaks any programs which use the undocumented `__Nonexhaustive` variants.

Fixes https://github.com/BurntSushi/rust-csv/issues/325