### PR TITLE
fix: ignore comment lines at end of file in CSV parser

### DIFF
--- a/csv-core/src/reader.rs
+++ b/csv-core/src/reader.rs
@@ -752,7 +752,10 @@ impl Reader {
         // parsing a new record, then we should sink into the final state
         // and never move from there. (pro-tip: the start state doubles as
         // the final state!)
-        if state >= self.dfa.final_record || state.is_start() || state == self.dfa.in_comment {
+        if state >= self.dfa.final_record
+            || state.is_start()
+            || state == self.dfa.in_comment
+        {
             self.dfa.new_state_final_end()
         } else {
             self.dfa.new_state_final_record()
@@ -1722,6 +1725,15 @@ mod tests {
         comment_5,
         "foo,#bar,baz",
         csv![["foo", "#bar", "baz"]],
+        |b: &mut ReaderBuilder| {
+            b.comment(Some(b'#'));
+        }
+    );
+    // ref: https://github.com/BurntSushi/rust-csv/issues/363
+    parses_to!(
+        comment_at_end_of_file_should_be_ignored,
+        "foo,bar,baz\n# this is a comment in last line",
+        csv![["foo", "bar", "baz"]],
         |b: &mut ReaderBuilder| {
             b.comment(Some(b'#'));
         }

--- a/csv-core/src/reader.rs
+++ b/csv-core/src/reader.rs
@@ -1731,8 +1731,16 @@ mod tests {
     );
     // ref: https://github.com/BurntSushi/rust-csv/issues/363
     parses_to!(
-        comment_at_end_of_file_should_be_ignored,
+        comment_at_end_of_file_should_be_ignored1,
         "foo,bar,baz\n# this is a comment in last line",
+        csv![["foo", "bar", "baz"]],
+        |b: &mut ReaderBuilder| {
+            b.comment(Some(b'#'));
+        }
+    );
+    parses_to!(
+        comment_at_end_of_file_should_be_ignored2,
+        "foo,bar,baz\n# this is a comment in last line\n",
         csv![["foo", "bar", "baz"]],
         |b: &mut ReaderBuilder| {
             b.comment(Some(b'#'));

--- a/csv-core/src/reader.rs
+++ b/csv-core/src/reader.rs
@@ -752,7 +752,7 @@ impl Reader {
         // parsing a new record, then we should sink into the final state
         // and never move from there. (pro-tip: the start state doubles as
         // the final state!)
-        if state >= self.dfa.final_record || state.is_start() {
+        if state >= self.dfa.final_record || state.is_start() || state == self.dfa.in_comment {
             self.dfa.new_state_final_end()
         } else {
             self.dfa.new_state_final_record()
@@ -1116,6 +1116,8 @@ struct Dfa {
     in_field: DfaState,
     /// The DFA state corresponding to being inside an quoted field.
     in_quoted: DfaState,
+    /// The DFA state corresponding to being inside a comment.
+    in_comment: DfaState,
     /// The minimum DFA state that indicates a field has been parsed. All DFA
     /// states greater than this are also final-field states.
     final_field: DfaState,
@@ -1132,6 +1134,7 @@ impl Dfa {
             classes: DfaClasses::new(),
             in_field: DfaState(0),
             in_quoted: DfaState(0),
+            in_comment: DfaState(0),
             final_field: DfaState(0),
             final_record: DfaState(0),
         }
@@ -1167,6 +1170,7 @@ impl Dfa {
     fn finish(&mut self) {
         self.in_field = self.new_state(NfaState::InField);
         self.in_quoted = self.new_state(NfaState::InQuotedField);
+        self.in_comment = self.new_state(NfaState::InComment);
         self.final_field = self.new_state(NfaState::EndFieldDelim);
         self.final_record = self.new_state(NfaState::EndRecord);
     }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -2641,16 +2641,13 @@ mod tests {
     fn comment_at_end_of_file_should_be_ignored() {
         // Reproduce https://github.com/BurntSushi/rust-csv/issues/363
         // Test data: the last line is a comment without a trailing newline
-        let data = b"foo,bar,baz\na,b,c\nd,e,f\n# this is a comment";
+        let data = b"foo,bar,baz\na,b,c\n# this is a comment";
         let mut rdr =
             ReaderBuilder::new().comment(Some(b'#')).from_reader(&data[..]);
         let mut rec = StringRecord::new();
         // First record
         assert!(rdr.read_record(&mut rec).unwrap());
         assert_eq!(rec, vec!["a", "b", "c"]);
-        // Second record
-        assert!(rdr.read_record(&mut rec).unwrap());
-        assert_eq!(rec, vec!["d", "e", "f"]);
         // The comment line at EOF should be ignored, no more records
         assert!(!rdr.read_record(&mut rec).unwrap());
     }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -2636,4 +2636,22 @@ mod tests {
         assert_eq!(rdr.headers().unwrap().len(), 0);
         assert_eq!(rdr.records().count(), 0);
     }
+
+    #[test]
+    fn comment_at_end_of_file_should_be_ignored() {
+        // Reproduce https://github.com/BurntSushi/rust-csv/issues/363
+        // Test data: the last line is a comment without a trailing newline
+        let data = b"foo,bar,baz\na,b,c\nd,e,f\n# this is a comment";
+        let mut rdr =
+            ReaderBuilder::new().comment(Some(b'#')).from_reader(&data[..]);
+        let mut rec = StringRecord::new();
+        // First record
+        assert!(rdr.read_record(&mut rec).unwrap());
+        assert_eq!(rec, vec!["a", "b", "c"]);
+        // Second record
+        assert!(rdr.read_record(&mut rec).unwrap());
+        assert_eq!(rec, vec!["d", "e", "f"]);
+        // The comment line at EOF should be ignored, no more records
+        assert!(!rdr.read_record(&mut rec).unwrap());
+    }
 }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -2636,19 +2636,4 @@ mod tests {
         assert_eq!(rdr.headers().unwrap().len(), 0);
         assert_eq!(rdr.records().count(), 0);
     }
-
-    #[test]
-    fn comment_at_end_of_file_should_be_ignored() {
-        // Reproduce https://github.com/BurntSushi/rust-csv/issues/363
-        // Test data: the last line is a comment without a trailing newline
-        let data = b"foo,bar,baz\na,b,c\n# this is a comment";
-        let mut rdr =
-            ReaderBuilder::new().comment(Some(b'#')).from_reader(&data[..]);
-        let mut rec = StringRecord::new();
-        // First record
-        assert!(rdr.read_record(&mut rec).unwrap());
-        assert_eq!(rec, vec!["a", "b", "c"]);
-        // The comment line at EOF should be ignored, no more records
-        assert!(!rdr.read_record(&mut rec).unwrap());
-    }
 }


### PR DESCRIPTION
This pull request fixes an issue in the CSV parser where comment lines at the end of a file were not properly ignored. 
According to expected behavior, if the last line(s) of a CSV file are comments (e.g., start with #), they should not be treated as data records, even if they appear at the end of the file without a trailing newline.

Fix: #363 

This is my first contribution to this project. If there are any issues with my implementation, code style, or the contribution process, please let me know. I am happy to make any necessary changes and appreciate your guidance. Thank you for your time and consideration!

