### PR TITLE
test: fix broken test after rust-lang/rust#115746

### DIFF
--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -86,7 +86,8 @@ quux,baz,foobar
 ";
     let mut cmd = cmd_for_example("tutorial-error-01");
     let out = cmd_output_with(&mut cmd, data.as_bytes());
-    assert!(out.stderr().contains("thread 'main' panicked"));
+    assert!(out.stderr().contains("thread 'main' "));
+    assert!(out.stderr().contains(" panicked"));
 }
 
 #[test]


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/115746 made the thread id get printed in panic messages, making the `tutorial_error_01_errored` test fail because it matched on the old panic message format.