### PR TITLE
Switch `serde` dependency to `serde_core`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,11 +24,11 @@ bench = false
 csv-core = { path = "csv-core", version = "0.1.11" }
 itoa = "1"
 ryu = "1"
-serde = "1.0.221"
+serde_core = "1.0.221"
 
 [dev-dependencies]
 bstr = { version = "1.7.0", default-features = false, features = ["alloc", "serde"] }
-serde = { version = "1.0.55", features = ["derive"] }
+serde = { version = "1.0.221", features = ["derive"] }
 
 [profile.release]
 debug = true

--- a/src/byte_record.rs
+++ b/src/byte_record.rs
@@ -5,7 +5,7 @@ use std::{
     result,
 };
 
-use serde::de::Deserialize;
+use serde_core::de::Deserialize;
 
 use crate::{
     deserializer::deserialize_byte_record,

--- a/src/deserializer.rs
+++ b/src/deserializer.rs
@@ -1,6 +1,6 @@
 use std::{error::Error as StdError, fmt, iter, num, str};
 
-use serde::{
+use serde_core::{
     de::value::BorrowedBytesDeserializer,
     de::{
         Deserialize, DeserializeSeed, Deserializer, EnumAccess,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,7 +137,7 @@ $ cargo run --example cookbook-read-serde < examples/data/smallpop.csv
 
 use std::result;
 
-use serde::{Deserialize, Deserializer};
+use serde_core::{Deserialize, Deserializer};
 
 pub use crate::{
     byte_record::{ByteRecord, ByteRecordIter, Position},

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -8,7 +8,7 @@ use std::{
 
 use {
     csv_core::{Reader as CoreReader, ReaderBuilder as CoreReaderBuilder},
-    serde::de::DeserializeOwned,
+    serde_core::de::DeserializeOwned,
 };
 
 use crate::{

--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -1,6 +1,6 @@
 use std::{fmt, io, mem};
 
-use serde::ser::{
+use serde_core::ser::{
     Error as SerdeError, Serialize, SerializeMap, SerializeSeq,
     SerializeStruct, SerializeStructVariant, SerializeTuple,
     SerializeTupleStruct, SerializeTupleVariant, Serializer,

--- a/src/string_record.rs
+++ b/src/string_record.rs
@@ -5,7 +5,7 @@ use std::{
     result, str,
 };
 
-use serde::de::Deserialize;
+use serde_core::de::Deserialize;
 
 use crate::{
     byte_record::{ByteRecord, ByteRecordIter, Position},

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -5,7 +5,7 @@ use {
         self, WriteResult, Writer as CoreWriter,
         WriterBuilder as CoreWriterBuilder,
     },
-    serde::Serialize,
+    serde_core::Serialize,
 };
 
 use crate::{


### PR DESCRIPTION
[serde_core](https://crates.io/crates/serde_core) has just been released. Crates that don't depend on serde derive macros should use it instead of `serde`, as it speeds up compile times by having the build for the crate itself be independent from `serde-derive` (in case it were to be enabled by some other crate). See the serde_core docs for more info.

While at it this also removes uses of `serde::serde_if_integer128!`, since all supported Rust versions in modern versions of serde support 128 bit integers https://github.com/serde-rs/serde/blob/3f6925125bae7837d918da63f2dba6efabad8dec/serde/src/integer128.rs.

On my Ryzen 5 5500U, the clean release build time for just `csv` in a project containing `csv`, and `serde` with the `derive` feature enabled, went from 6.97s to 4.06s.