### PR TITLE
Add optional `serde` feature (enabled by default)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,11 @@ members = ["csv-core", "csv-index"]
 [lib]
 bench = false
 
+# Allow for needless main in doctest, as some examples are tutorials.
+[lints.clippy]
+needless_doctest_main = "allow"
+upper_case_acronyms = "allow"
+
 [dependencies]
 csv-core = { path = "csv-core", version = "0.1.11" }
 itoa = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,14 +24,176 @@ bench = false
 csv-core = { path = "csv-core", version = "0.1.11" }
 itoa = "1"
 ryu = "1"
-serde_core = "1.0.221"
+serde_core = {version = "1.0.221", optional = true }
 
 [dev-dependencies]
 bstr = { version = "1.7.0", default-features = false, features = ["alloc", "serde"] }
 serde = { version = "1.0.221", features = ["derive"] }
+
+[features]
+default = ["serde"]
+serde = ["dep:serde_core"]
 
 [profile.release]
 debug = true
 
 [profile.bench]
 debug = true
+
+[[example]]
+name = "cookbook-read-basic"
+path = "examples/cookbook-read-basic.rs"
+
+[[example]]
+name = "cookbook-read-colon"
+path = "examples/cookbook-read-colon.rs"
+
+[[example]]
+name = "cookbook-read-no-headers"
+path = "examples/cookbook-read-no-headers.rs"
+
+[[example]]
+name = "cookbook-read-serde"
+path = "examples/cookbook-read-serde.rs"
+required-features = ["serde"]
+
+[[example]]
+name = "cookbook-write-basic"
+path = "examples/cookbook-write-basic.rs"
+
+[[example]]
+name = "cookbook-write-serde"
+path = "examples/cookbook-write-serde.rs"
+required-features = ["serde"]
+
+[[example]]
+name = "tutorial-error-01"
+path = "examples/tutorial-error-01.rs"
+
+[[example]]
+name = "tutorial-error-02"
+path = "examples/tutorial-error-02.rs"
+
+[[example]]
+name = "tutorial-error-03"
+path = "examples/tutorial-error-03.rs"
+
+[[example]]
+name = "tutorial-error-04"
+path = "examples/tutorial-error-04.rs"
+
+[[example]]
+name = "tutorial-perf-alloc-01"
+path = "examples/tutorial-perf-alloc-01.rs"
+
+[[example]]
+name = "tutorial-perf-alloc-02"
+path = "examples/tutorial-perf-alloc-02.rs"
+
+[[example]]
+name = "tutorial-perf-alloc-03"
+path = "examples/tutorial-perf-alloc-03.rs"
+
+[[example]]
+name = "tutorial-perf-core-01"
+path = "examples/tutorial-perf-core-01.rs"
+
+[[example]]
+name = "tutorial-perf-serde-01"
+path = "examples/tutorial-perf-serde-01.rs"
+required-features = ["serde"]
+
+[[example]]
+name = "tutorial-perf-serde-02"
+path = "examples/tutorial-perf-serde-02.rs"
+required-features = ["serde"]
+
+[[example]]
+name = "tutorial-perf-serde-03"
+path = "examples/tutorial-perf-serde-03.rs"
+required-features = ["serde"]
+
+[[example]]
+name = "tutorial-pipeline-pop-01"
+path = "examples/tutorial-pipeline-pop-01.rs"
+required-features = ["serde"]
+
+[[example]]
+name = "tutorial-pipeline-search-01"
+path = "examples/tutorial-pipeline-search-01.rs"
+
+[[example]]
+name = "tutorial-pipeline-search-02"
+path = "examples/tutorial-pipeline-search-02.rs"
+
+[[example]]
+name = "tutorial-read-01"
+path = "examples/tutorial-read-01.rs"
+
+[[example]]
+name = "tutorial-read-delimiter-01"
+path = "examples/tutorial-read-delimiter-01.rs"
+
+[[example]]
+name = "tutorial-read-headers-01"
+path = "examples/tutorial-read-headers-01.rs"
+
+[[example]]
+name = "tutorial-read-headers-02"
+path = "examples/tutorial-read-headers-02.rs"
+
+[[example]]
+name = "tutorial-read-serde-01"
+path = "examples/tutorial-read-serde-01.rs"
+required-features = ["serde"]
+
+[[example]]
+name = "tutorial-read-serde-02"
+path = "examples/tutorial-read-serde-02.rs"
+required-features = ["serde"]
+
+[[example]]
+name = "tutorial-read-serde-03"
+path = "examples/tutorial-read-serde-03.rs"
+required-features = ["serde"]
+
+[[example]]
+name = "tutorial-read-serde-04"
+path = "examples/tutorial-read-serde-04.rs"
+required-features = ["serde"]
+
+[[example]]
+name = "tutorial-read-serde-invalid-01"
+path = "examples/tutorial-read-serde-invalid-01.rs"
+required-features = ["serde"]
+
+[[example]]
+name = "tutorial-read-serde-invalid-02"
+path = "examples/tutorial-read-serde-invalid-02.rs"
+required-features = ["serde"]
+
+[[example]]
+name = "tutorial-setup-01"
+path = "examples/tutorial-setup-01.rs"
+
+[[example]]
+name = "tutorial-write-01"
+path = "examples/tutorial-write-01.rs"
+
+[[example]]
+name = "tutorial-write-02"
+path = "examples/tutorial-write-02.rs"
+
+[[example]]
+name = "tutorial-write-delimiter-01"
+path = "examples/tutorial-write-delimiter-01.rs"
+
+[[example]]
+name = "tutorial-write-serde-01"
+path = "examples/tutorial-write-serde-01.rs"
+required-features = ["serde"]
+
+[[example]]
+name = "tutorial-write-serde-02"
+path = "examples/tutorial-write-serde-02.rs"
+required-features = ["serde"]

--- a/ci/check-copy
+++ b/ci/check-copy
@@ -15,13 +15,13 @@ SOURCE="$1"
 
 errored() {
     rm -rf "$TMPDIR"
-    echo "HINT: please run scripts/copy-examples" >&2
+    echo "HINT: please run scripts/copy-examples.py" >&2
     exit 1
 }
 
 # Make sure the right rustfmt config is available.
 cp "$REPO/rustfmt.toml" "$TMPDIR/"
-"$SCRIPTS/copy-examples" \
+"$SCRIPTS/copy-examples.py" \
   --rust-file "$REPO/src/$SOURCE.rs" \
   --example-dir "$TMPDIR"
 for new in "$TMPDIR"/*.rs; do

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -12,6 +12,7 @@ if [ "$TRAVIS_RUST_VERSION" = "1.33.0" ]; then
 fi
 
 cargo test --verbose
+cargo test --verbose --no-default-features
 cargo test --verbose --manifest-path csv-core/Cargo.toml
 cargo test --verbose --manifest-path csv-index/Cargo.toml
 if [ "$TRAVIS_RUST_VERSION" = "stable" ]; then

--- a/csv-core/src/writer.rs
+++ b/csv-core/src/writer.rs
@@ -217,7 +217,7 @@ impl fmt::Debug for Writer {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 struct WriterState {
     /// This is set whenever we've begun writing the contents of a field, even
     /// if the contents are empty. We use it to avoid re-computing whether
@@ -493,12 +493,6 @@ impl Writer {
 impl Default for Writer {
     fn default() -> Writer {
         WriterBuilder::new().build()
-    }
-}
-
-impl Default for WriterState {
-    fn default() -> WriterState {
-        WriterState { in_field: false, quoting: false, record_bytes: 0 }
     }
 }
 

--- a/examples/cookbook-read-serde.rs
+++ b/examples/cookbook-read-serde.rs
@@ -1,12 +1,10 @@
-#![cfg(feature = "serde")]
 #![allow(dead_code)]
 use std::{error::Error, io, process};
 
-use serde::Deserialize;
-
+#[cfg(feature = "serde")]
 // By default, struct field names are deserialized based on the position of
 // a corresponding field in the CSV data's header record.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, serde::Deserialize)]
 struct Record {
     city: String,
     region: String,
@@ -14,6 +12,7 @@ struct Record {
     population: Option<u64>,
 }
 
+#[cfg(feature = "serde")]
 fn example() -> Result<(), Box<dyn Error>> {
     let mut rdr = csv::Reader::from_reader(io::stdin());
     for result in rdr.deserialize() {
@@ -25,9 +24,14 @@ fn example() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
+#[cfg(feature = "serde")]
 fn main() {
     if let Err(err) = example() {
         println!("error running example: {}", err);
         process::exit(1);
     }
+}
+#[cfg(not(feature = "serde"))]
+fn main() {
+    println!("this example requires the 'serde' feature");
 }

--- a/examples/cookbook-read-serde.rs
+++ b/examples/cookbook-read-serde.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "serde")]
 #![allow(dead_code)]
 use std::{error::Error, io, process};
 

--- a/examples/cookbook-write-serde.rs
+++ b/examples/cookbook-write-serde.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "serde")]
 use std::{error::Error, io, process};
 
 use serde::Serialize;

--- a/examples/cookbook-write-serde.rs
+++ b/examples/cookbook-write-serde.rs
@@ -1,9 +1,7 @@
-#![cfg(feature = "serde")]
 use std::{error::Error, io, process};
 
-use serde::Serialize;
-
-#[derive(Debug, Serialize)]
+#[cfg(feature = "serde")]
+#[derive(Debug, serde::Serialize)]
 struct Record {
     city: String,
     region: String,
@@ -11,6 +9,7 @@ struct Record {
     population: Option<u64>,
 }
 
+#[cfg(feature = "serde")]
 fn example() -> Result<(), Box<dyn Error>> {
     let mut wtr = csv::Writer::from_writer(io::stdout());
 
@@ -32,9 +31,14 @@ fn example() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
+#[cfg(feature = "serde")]
 fn main() {
     if let Err(err) = example() {
         println!("error running example: {}", err);
         process::exit(1);
     }
+}
+#[cfg(not(feature = "serde"))]
+fn main() {
+    println!("this example requires the 'serde' feature");
 }

--- a/examples/tutorial-perf-serde-01.rs
+++ b/examples/tutorial-perf-serde-01.rs
@@ -1,10 +1,8 @@
-#![cfg(feature = "serde")]
 #![allow(dead_code)]
 use std::{error::Error, io, process};
 
-use serde::Deserialize;
-
-#[derive(Debug, Deserialize)]
+#[cfg(feature = "serde")]
+#[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "PascalCase")]
 struct Record {
     country: String,
@@ -16,6 +14,7 @@ struct Record {
     longitude: f64,
 }
 
+#[cfg(feature = "serde")]
 fn run() -> Result<u64, Box<dyn Error>> {
     let mut rdr = csv::Reader::from_reader(io::stdin());
 
@@ -29,6 +28,7 @@ fn run() -> Result<u64, Box<dyn Error>> {
     Ok(count)
 }
 
+#[cfg(feature = "serde")]
 fn main() {
     match run() {
         Ok(count) => {
@@ -39,4 +39,8 @@ fn main() {
             process::exit(1);
         }
     }
+}
+#[cfg(not(feature = "serde"))]
+fn main() {
+    println!("this example requires the 'serde' feature");
 }

--- a/examples/tutorial-perf-serde-01.rs
+++ b/examples/tutorial-perf-serde-01.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "serde")]
 #![allow(dead_code)]
 use std::{error::Error, io, process};
 

--- a/examples/tutorial-perf-serde-02.rs
+++ b/examples/tutorial-perf-serde-02.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "serde")]
 #![allow(dead_code)]
 use serde::Deserialize;
 use std::{error::Error, io, process};

--- a/examples/tutorial-perf-serde-02.rs
+++ b/examples/tutorial-perf-serde-02.rs
@@ -1,9 +1,7 @@
-#![cfg(feature = "serde")]
 #![allow(dead_code)]
-use serde::Deserialize;
 use std::{error::Error, io, process};
-
-#[derive(Debug, Deserialize)]
+#[cfg(feature = "serde")]
+#[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "PascalCase")]
 struct Record<'a> {
     country: &'a str,
@@ -15,6 +13,7 @@ struct Record<'a> {
     longitude: f64,
 }
 
+#[cfg(feature = "serde")]
 fn run() -> Result<u64, Box<dyn Error>> {
     let mut rdr = csv::Reader::from_reader(io::stdin());
     let mut raw_record = csv::StringRecord::new();
@@ -30,6 +29,7 @@ fn run() -> Result<u64, Box<dyn Error>> {
     Ok(count)
 }
 
+#[cfg(feature = "serde")]
 fn main() {
     match run() {
         Ok(count) => {
@@ -40,4 +40,8 @@ fn main() {
             process::exit(1);
         }
     }
+}
+#[cfg(not(feature = "serde"))]
+fn main() {
+    println!("this example requires the 'serde' feature");
 }

--- a/examples/tutorial-perf-serde-03.rs
+++ b/examples/tutorial-perf-serde-03.rs
@@ -1,10 +1,8 @@
-#![cfg(feature = "serde")]
 #![allow(dead_code)]
 use std::{error::Error, io, process};
 
-use serde::Deserialize;
-
-#[derive(Debug, Deserialize)]
+#[cfg(feature = "serde")]
+#[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "PascalCase")]
 struct Record<'a> {
     country: &'a [u8],
@@ -16,6 +14,7 @@ struct Record<'a> {
     longitude: f64,
 }
 
+#[cfg(feature = "serde")]
 fn run() -> Result<u64, Box<dyn Error>> {
     let mut rdr = csv::Reader::from_reader(io::stdin());
     let mut raw_record = csv::ByteRecord::new();
@@ -31,6 +30,7 @@ fn run() -> Result<u64, Box<dyn Error>> {
     Ok(count)
 }
 
+#[cfg(feature = "serde")]
 fn main() {
     match run() {
         Ok(count) => {
@@ -41,4 +41,8 @@ fn main() {
             process::exit(1);
         }
     }
+}
+#[cfg(not(feature = "serde"))]
+fn main() {
+    println!("this example requires the 'serde' feature");
 }

--- a/examples/tutorial-perf-serde-03.rs
+++ b/examples/tutorial-perf-serde-03.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "serde")]
 #![allow(dead_code)]
 use std::{error::Error, io, process};
 

--- a/examples/tutorial-pipeline-pop-01.rs
+++ b/examples/tutorial-pipeline-pop-01.rs
@@ -1,11 +1,9 @@
-#![cfg(feature = "serde")]
 use std::{env, error::Error, io, process};
 
-use serde::{Deserialize, Serialize};
-
+#[cfg(feature = "serde")]
 // Unlike previous examples, we derive both Deserialize and Serialize. This
 // means we'll be able to automatically deserialize and serialize this type.
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "PascalCase")]
 struct Record {
     city: String,
@@ -15,6 +13,7 @@ struct Record {
     longitude: f64,
 }
 
+#[cfg(feature = "serde")]
 fn run() -> Result<(), Box<dyn Error>> {
     // Get the query from the positional arguments.
     // If one doesn't exist or isn't an integer, return an error.
@@ -50,9 +49,14 @@ fn run() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
+#[cfg(feature = "serde")]
 fn main() {
     if let Err(err) = run() {
         println!("{}", err);
         process::exit(1);
     }
+}
+#[cfg(not(feature = "serde"))]
+fn main() {
+    println!("this example requires the 'serde' feature");
 }

--- a/examples/tutorial-pipeline-pop-01.rs
+++ b/examples/tutorial-pipeline-pop-01.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "serde")]
 use std::{env, error::Error, io, process};
 
 use serde::{Deserialize, Serialize};

--- a/examples/tutorial-read-serde-02.rs
+++ b/examples/tutorial-read-serde-02.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "serde")]
 use std::{error::Error, io, process};
 
 // This introduces a type alias so that we can conveniently reference our

--- a/examples/tutorial-read-serde-02.rs
+++ b/examples/tutorial-read-serde-02.rs
@@ -1,10 +1,11 @@
-#![cfg(feature = "serde")]
+#[allow(dead_code)]
 use std::{error::Error, io, process};
 
 // This introduces a type alias so that we can conveniently reference our
 // record type.
 type Record = (String, String, Option<u64>, f64, f64);
 
+#[cfg(feature = "serde")]
 fn run() -> Result<(), Box<dyn Error>> {
     let mut rdr = csv::Reader::from_reader(io::stdin());
     // Instead of creating an iterator with the `records` method, we create
@@ -17,9 +18,14 @@ fn run() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
+#[cfg(feature = "serde")]
 fn main() {
     if let Err(err) = run() {
         println!("{}", err);
         process::exit(1);
     }
+}
+#[cfg(not(feature = "serde"))]
+fn main() {
+    println!("this example requires the 'serde' feature");
 }

--- a/examples/tutorial-read-serde-03.rs
+++ b/examples/tutorial-read-serde-03.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "serde")]
+#[allow(dead_code)]
 use std::collections::HashMap;
 use std::{error::Error, io, process};
 
@@ -6,6 +6,7 @@ use std::{error::Error, io, process};
 // record type.
 type Record = HashMap<String, String>;
 
+#[cfg(feature = "serde")]
 fn run() -> Result<(), Box<dyn Error>> {
     let mut rdr = csv::Reader::from_reader(io::stdin());
     for result in rdr.deserialize() {
@@ -15,9 +16,14 @@ fn run() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
+#[cfg(feature = "serde")]
 fn main() {
     if let Err(err) = run() {
         println!("{}", err);
         process::exit(1);
     }
+}
+#[cfg(not(feature = "serde"))]
+fn main() {
+    println!("this example requires the 'serde' feature");
 }

--- a/examples/tutorial-read-serde-03.rs
+++ b/examples/tutorial-read-serde-03.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "serde")]
 use std::collections::HashMap;
 use std::{error::Error, io, process};
 

--- a/examples/tutorial-read-serde-04.rs
+++ b/examples/tutorial-read-serde-04.rs
@@ -1,8 +1,9 @@
-#![cfg(feature = "serde")]
 #![allow(dead_code)]
+#[cfg(feature = "serde")]
 use std::{error::Error, io, process};
 
 // This lets us write `#[derive(Deserialize)]`.
+#[cfg(feature = "serde")]
 use serde::Deserialize;
 
 // We don't need to derive `Debug` (which doesn't require Serde), but it's a
@@ -10,6 +11,7 @@ use serde::Deserialize;
 //
 // Notice that the field names in this struct are NOT in the same order as
 // the fields in the CSV data!
+#[cfg(feature = "serde")]
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 struct Record {
@@ -20,6 +22,7 @@ struct Record {
     state: String,
 }
 
+#[cfg(feature = "serde")]
 fn run() -> Result<(), Box<dyn Error>> {
     let mut rdr = csv::Reader::from_reader(io::stdin());
     for result in rdr.deserialize() {
@@ -31,9 +34,14 @@ fn run() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
+#[cfg(feature = "serde")]
 fn main() {
     if let Err(err) = run() {
         println!("{}", err);
         process::exit(1);
     }
+}
+#[cfg(not(feature = "serde"))]
+fn main() {
+    println!("this example requires the 'serde' feature");
 }

--- a/examples/tutorial-read-serde-04.rs
+++ b/examples/tutorial-read-serde-04.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "serde")]
 #![allow(dead_code)]
 use std::{error::Error, io, process};
 

--- a/examples/tutorial-read-serde-invalid-01.rs
+++ b/examples/tutorial-read-serde-invalid-01.rs
@@ -1,10 +1,7 @@
-#![cfg(feature = "serde")]
 #![allow(dead_code)]
 use std::{error::Error, io, process};
-
-use serde::Deserialize;
-
-#[derive(Debug, Deserialize)]
+#[cfg(feature = "serde")]
+#[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "PascalCase")]
 struct Record {
     latitude: f64,
@@ -14,6 +11,7 @@ struct Record {
     state: String,
 }
 
+#[cfg(feature = "serde")]
 fn run() -> Result<(), Box<dyn Error>> {
     let mut rdr = csv::Reader::from_reader(io::stdin());
     for result in rdr.deserialize() {
@@ -22,10 +20,14 @@ fn run() -> Result<(), Box<dyn Error>> {
     }
     Ok(())
 }
-
+#[cfg(feature = "serde")]
 fn main() {
     if let Err(err) = run() {
         println!("{}", err);
         process::exit(1);
     }
+}
+#[cfg(not(feature = "serde"))]
+fn main() {
+    println!("this example requires the 'serde' feature");
 }

--- a/examples/tutorial-read-serde-invalid-01.rs
+++ b/examples/tutorial-read-serde-invalid-01.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "serde")]
 #![allow(dead_code)]
 use std::{error::Error, io, process};
 

--- a/examples/tutorial-read-serde-invalid-02.rs
+++ b/examples/tutorial-read-serde-invalid-02.rs
@@ -1,9 +1,7 @@
-#![cfg(feature = "serde")]
 #![allow(dead_code)]
 use std::{error::Error, io, process};
-
-use serde::Deserialize;
-#[derive(Debug, Deserialize)]
+#[cfg(feature = "serde")]
+#[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "PascalCase")]
 struct Record {
     latitude: f64,
@@ -13,7 +11,7 @@ struct Record {
     city: String,
     state: String,
 }
-
+#[cfg(feature = "serde")]
 fn run() -> Result<(), Box<dyn Error>> {
     let mut rdr = csv::Reader::from_reader(io::stdin());
     for result in rdr.deserialize() {
@@ -22,10 +20,14 @@ fn run() -> Result<(), Box<dyn Error>> {
     }
     Ok(())
 }
-
+#[cfg(feature = "serde")]
 fn main() {
     if let Err(err) = run() {
         println!("{}", err);
         process::exit(1);
     }
+}
+#[cfg(not(feature = "serde"))]
+fn main() {
+    println!("this example requires the 'serde' feature");
 }

--- a/examples/tutorial-read-serde-invalid-02.rs
+++ b/examples/tutorial-read-serde-invalid-02.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "serde")]
 #![allow(dead_code)]
 use std::{error::Error, io, process};
 

--- a/examples/tutorial-write-serde-01.rs
+++ b/examples/tutorial-write-serde-01.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "serde")]
 use std::{error::Error, io, process};
 
 fn run() -> Result<(), Box<dyn Error>> {

--- a/examples/tutorial-write-serde-01.rs
+++ b/examples/tutorial-write-serde-01.rs
@@ -1,6 +1,5 @@
-#![cfg(feature = "serde")]
 use std::{error::Error, io, process};
-
+#[cfg(feature = "serde")]
 fn run() -> Result<(), Box<dyn Error>> {
     let mut wtr = csv::Writer::from_writer(io::stdout());
 
@@ -32,10 +31,14 @@ fn run() -> Result<(), Box<dyn Error>> {
     wtr.flush()?;
     Ok(())
 }
-
+#[cfg(feature = "serde")]
 fn main() {
     if let Err(err) = run() {
         println!("{}", err);
         process::exit(1);
     }
+}
+#[cfg(not(feature = "serde"))]
+fn main() {
+    println!("this example requires the 'serde' feature");
 }

--- a/examples/tutorial-write-serde-02.rs
+++ b/examples/tutorial-write-serde-02.rs
@@ -1,10 +1,8 @@
-#![cfg(feature = "serde")]
 use std::{error::Error, io, process};
 
-use serde::Serialize;
-
+#[cfg(feature = "serde")]
 // Note that structs can derive both Serialize and Deserialize!
-#[derive(Debug, Serialize)]
+#[derive(Debug, serde::Serialize)]
 #[serde(rename_all = "PascalCase")]
 struct Record<'a> {
     city: &'a str,
@@ -14,6 +12,7 @@ struct Record<'a> {
     longitude: f64,
 }
 
+#[cfg(feature = "serde")]
 fn run() -> Result<(), Box<dyn Error>> {
     let mut wtr = csv::Writer::from_writer(io::stdout());
 
@@ -43,9 +42,14 @@ fn run() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
+#[cfg(feature = "serde")]
 fn main() {
     if let Err(err) = run() {
         println!("{}", err);
         process::exit(1);
     }
+}
+#[cfg(not(feature = "serde"))]
+fn main() {
+    println!("this example requires the 'serde' feature");
 }

--- a/examples/tutorial-write-serde-02.rs
+++ b/examples/tutorial-write-serde-02.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "serde")]
 use std::{error::Error, io, process};
 
 use serde::Serialize;

--- a/scripts/copy-examples.py
+++ b/scripts/copy-examples.py
@@ -19,15 +19,15 @@ if __name__ == '__main__':
 
     with codecs.open(args.rust_file, encoding='utf-8') as f:
         rustcode = f.read()
-    for m in RE_EACH_CODE_BLOCK.finditer(rustcode):
-        lines = m.group(1).splitlines()
+    for match in RE_EACH_CODE_BLOCK.finditer(rustcode):
+        lines = match.group(1).splitlines()
         marker, codelines = lines[0], lines[1:]
-        m = RE_MARKER.search(marker)
-        if m is None:
+        maybe_match = RE_MARKER.search(marker)
+        if maybe_match is None:
             continue
 
         code = '\n'.join(RE_STRIP_COMMENT.sub('', line) for line in codelines)
-        fpath = os.path.join(args.example_dir, m.group(1))
+        fpath = os.path.join(args.example_dir, maybe_match.group(1))
         with codecs.open(fpath, mode='w+', encoding='utf-8') as f:
             print(code, file=f)
         subprocess.check_output(['rustfmt', fpath])

--- a/src/byte_record.rs
+++ b/src/byte_record.rs
@@ -5,11 +5,8 @@ use std::{
     result,
 };
 
-use serde_core::de::Deserialize;
-
 use crate::{
-    deserializer::deserialize_byte_record,
-    error::{new_utf8_error, Result, Utf8Error},
+    error::{new_utf8_error, Utf8Error},
     string_record::StringRecord,
 };
 
@@ -144,6 +141,7 @@ impl ByteRecord {
         }))
     }
 
+    #[cfg(feature = "serde")]
     /// Deserialize this record.
     ///
     /// The `D` type parameter refers to the type that this record should be
@@ -229,11 +227,11 @@ impl ByteRecord {
     ///     Ok(())
     /// }
     /// ```
-    pub fn deserialize<'de, D: Deserialize<'de>>(
+    pub fn deserialize<'de, D: serde_core::de::Deserialize<'de>>(
         &'de self,
         headers: Option<&'de ByteRecord>,
-    ) -> Result<D> {
-        deserialize_byte_record(self, headers)
+    ) -> crate::error::Result<D> {
+        crate::deserializer::deserialize_byte_record(self, headers)
     }
 
     /// Returns an iterator over all fields in this record.

--- a/src/byte_record.rs
+++ b/src/byte_record.rs
@@ -592,6 +592,13 @@ pub struct Position {
     record: u64,
 }
 
+impl Default for Position {
+    #[inline]
+    fn default() -> Position {
+        Position::new()
+    }
+}
+
 impl Position {
     /// Returns a new position initialized to the start value.
     #[inline]

--- a/src/cookbook.rs
+++ b/src/cookbook.rs
@@ -73,6 +73,7 @@ method.
 ```no_run
 # //cookbook-read-serde.rs
 # #![allow(dead_code)]
+# #[cfg(feature = "serde")] {
 use std::{error::Error, io, process};
 
 use serde::Deserialize;
@@ -104,6 +105,12 @@ fn main() {
         process::exit(1);
     }
 }
+# }
+# #[cfg(not(feature = "serde"))] {
+# fn main() {
+#     println!("this example requires the 'serde' feature");
+# }
+# }
 ```
 
 The above example can be run like so:
@@ -232,6 +239,7 @@ headers are written automatically.
 
 ```no_run
 # //cookbook-write-serde.rs
+# #[cfg(feature = "serde")] {
 use std::{error::Error, io, process};
 
 use serde::Serialize;
@@ -271,6 +279,12 @@ fn main() {
         process::exit(1);
     }
 }
+# }
+# #[cfg(not(feature = "serde"))] {
+# fn main() {
+#     println!("this example requires the 'serde' feature");
+# }
+# }
 ```
 
 The above example can be run like so:

--- a/src/cookbook.rs
+++ b/src/cookbook.rs
@@ -73,14 +73,12 @@ method.
 ```no_run
 # //cookbook-read-serde.rs
 # #![allow(dead_code)]
-# #[cfg(feature = "serde")] {
 use std::{error::Error, io, process};
 
-use serde::Deserialize;
-
+# #[cfg(feature = "serde")]
 // By default, struct field names are deserialized based on the position of
 // a corresponding field in the CSV data's header record.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, serde::Deserialize)]
 struct Record {
     city: String,
     region: String,
@@ -88,6 +86,7 @@ struct Record {
     population: Option<u64>,
 }
 
+# #[cfg(feature = "serde")]
 fn example() -> Result<(), Box<dyn Error>> {
     let mut rdr = csv::Reader::from_reader(io::stdin());
     for result in rdr.deserialize() {
@@ -99,17 +98,16 @@ fn example() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
+# #[cfg(feature = "serde")]
 fn main() {
     if let Err(err) = example() {
         println!("error running example: {}", err);
         process::exit(1);
     }
 }
-# }
-# #[cfg(not(feature = "serde"))] {
+# #[cfg(not(feature = "serde"))]
 # fn main() {
 #     println!("this example requires the 'serde' feature");
-# }
 # }
 ```
 
@@ -239,12 +237,10 @@ headers are written automatically.
 
 ```no_run
 # //cookbook-write-serde.rs
-# #[cfg(feature = "serde")] {
 use std::{error::Error, io, process};
 
-use serde::Serialize;
-
-#[derive(Debug, Serialize)]
+# #[cfg(feature = "serde")]
+#[derive(Debug, serde::Serialize)]
 struct Record {
     city: String,
     region: String,
@@ -252,6 +248,7 @@ struct Record {
     population: Option<u64>,
 }
 
+# #[cfg(feature = "serde")]
 fn example() -> Result<(), Box<dyn Error>> {
     let mut wtr = csv::Writer::from_writer(io::stdout());
 
@@ -273,17 +270,16 @@ fn example() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
+# #[cfg(feature = "serde")]
 fn main() {
     if let Err(err) = example() {
         println!("error running example: {}", err);
         process::exit(1);
     }
 }
-# }
-# #[cfg(not(feature = "serde"))] {
+# #[cfg(not(feature = "serde"))]
 # fn main() {
 #     println!("this example requires the 'serde' feature");
-# }
 # }
 ```
 

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -31,7 +31,7 @@ impl<'a> core::fmt::Debug for Bytes<'a> {
                 | '\x7f' => {
                     write!(f, "\\x{:02x}", u32::from(ch))?;
                 }
-                '\n' | '\r' | '\t' | _ => {
+                _ => {
                     write!(f, "{}", ch.escape_debug())?;
                 }
             }

--- a/src/deserializer.rs
+++ b/src/deserializer.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "serde")]
 use std::{error::Error as StdError, fmt, iter, num, str};
 
 use serde_core::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,9 +94,9 @@ By default, the member names of the struct are matched with the values in the
 header record of your CSV data.
 
 ```no_run
-# #[cfg(feature = "serde")] {
 use std::{error::Error, io, process};
 
+# #[cfg(feature = "serde")]
 #[derive(Debug, serde::Deserialize)]
 struct Record {
     city: String,
@@ -105,6 +105,7 @@ struct Record {
     population: Option<u64>,
 }
 
+# #[cfg(feature = "serde")]
 fn example() -> Result<(), Box<dyn Error>> {
     let mut rdr = csv::Reader::from_reader(io::stdin());
     for result in rdr.deserialize() {
@@ -116,17 +117,16 @@ fn example() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
+# #[cfg(feature = "serde")]
 fn main() {
     if let Err(err) = example() {
         println!("error running example: {}", err);
         process::exit(1);
     }
 }
-# }
-# #[cfg(not(feature = "serde"))] {
+# #[cfg(not(feature = "serde"))]
 # fn main() {
 #     println!("this example requires the 'serde' feature");
-# }
 # }
 ```
 

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1,15 +1,11 @@
 use std::{
     fs::File,
     io::{self, BufRead, Seek},
-    marker::PhantomData,
     path::Path,
     result,
 };
 
-use {
-    csv_core::{Reader as CoreReader, ReaderBuilder as CoreReaderBuilder},
-    serde_core::de::DeserializeOwned,
-};
+use csv_core::{Reader as CoreReader, ReaderBuilder as CoreReaderBuilder};
 
 use crate::{
     byte_record::{ByteRecord, Position},
@@ -870,6 +866,7 @@ impl<R: io::Read> Reader<R> {
         ReaderBuilder::new().from_reader(rdr)
     }
 
+    #[cfg(feature = "serde")]
     /// Returns a borrowed iterator over deserialized records.
     ///
     /// Each item yielded by this iterator is a `Result<D, Error>`.
@@ -1047,11 +1044,12 @@ impl<R: io::Read> Reader<R> {
     /// ```
     pub fn deserialize<D>(&mut self) -> DeserializeRecordsIter<'_, R, D>
     where
-        D: DeserializeOwned,
+        D: serde_core::de::DeserializeOwned,
     {
         DeserializeRecordsIter::new(self)
     }
 
+    #[cfg(feature = "serde")]
     /// Returns an owned iterator over deserialized records.
     ///
     /// Each item yielded by this iterator is a `Result<D, Error>`.
@@ -1107,7 +1105,7 @@ impl<R: io::Read> Reader<R> {
     /// ```
     pub fn into_deserialize<D>(self) -> DeserializeRecordsIntoIter<R, D>
     where
-        D: DeserializeOwned,
+        D: serde_core::de::DeserializeOwned,
     {
         DeserializeRecordsIntoIter::new(self)
     }
@@ -1900,6 +1898,7 @@ impl ReaderState {
     }
 }
 
+#[cfg(feature = "serde")]
 /// An owned iterator over deserialized records.
 ///
 /// The type parameter `R` refers to the underlying `io::Read` type, and `D`
@@ -1908,10 +1907,11 @@ pub struct DeserializeRecordsIntoIter<R, D> {
     rdr: Reader<R>,
     rec: StringRecord,
     headers: Option<StringRecord>,
-    _priv: PhantomData<D>,
+    _priv: std::marker::PhantomData<D>,
 }
 
-impl<R: io::Read, D: DeserializeOwned> DeserializeRecordsIntoIter<R, D> {
+#[cfg(feature = "serde")]
+impl<R: io::Read, D> DeserializeRecordsIntoIter<R, D> {
     fn new(mut rdr: Reader<R>) -> DeserializeRecordsIntoIter<R, D> {
         let headers = if !rdr.state.has_headers {
             None
@@ -1922,7 +1922,7 @@ impl<R: io::Read, D: DeserializeOwned> DeserializeRecordsIntoIter<R, D> {
             rdr,
             rec: StringRecord::new(),
             headers,
-            _priv: PhantomData,
+            _priv: std::marker::PhantomData,
         }
     }
 
@@ -1942,7 +1942,8 @@ impl<R: io::Read, D: DeserializeOwned> DeserializeRecordsIntoIter<R, D> {
     }
 }
 
-impl<R: io::Read, D: DeserializeOwned> Iterator
+#[cfg(feature = "serde")]
+impl<R: io::Read, D: serde_core::de::DeserializeOwned> Iterator
     for DeserializeRecordsIntoIter<R, D>
 {
     type Item = Result<D>;
@@ -1956,6 +1957,7 @@ impl<R: io::Read, D: DeserializeOwned> Iterator
     }
 }
 
+#[cfg(feature = "serde")]
 /// A borrowed iterator over deserialized records.
 ///
 /// The lifetime parameter `'r` refers to the lifetime of the underlying
@@ -1966,10 +1968,11 @@ pub struct DeserializeRecordsIter<'r, R: 'r, D> {
     rdr: &'r mut Reader<R>,
     rec: StringRecord,
     headers: Option<StringRecord>,
-    _priv: PhantomData<D>,
+    _priv: std::marker::PhantomData<D>,
 }
 
-impl<'r, R: io::Read, D: DeserializeOwned> DeserializeRecordsIter<'r, R, D> {
+#[cfg(feature = "serde")]
+impl<'r, R: io::Read, D> DeserializeRecordsIter<'r, R, D> {
     fn new(rdr: &'r mut Reader<R>) -> DeserializeRecordsIter<'r, R, D> {
         let headers = if !rdr.state.has_headers {
             None
@@ -1980,7 +1983,7 @@ impl<'r, R: io::Read, D: DeserializeOwned> DeserializeRecordsIter<'r, R, D> {
             rdr,
             rec: StringRecord::new(),
             headers,
-            _priv: PhantomData,
+            _priv: std::marker::PhantomData,
         }
     }
 
@@ -1995,7 +1998,8 @@ impl<'r, R: io::Read, D: DeserializeOwned> DeserializeRecordsIter<'r, R, D> {
     }
 }
 
-impl<'r, R: io::Read, D: DeserializeOwned> Iterator
+#[cfg(feature = "serde")]
+impl<'r, R: io::Read, D: serde_core::de::DeserializeOwned> Iterator
     for DeserializeRecordsIter<'r, R, D>
 {
     type Item = Result<D>;

--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "serde")]
 use std::{fmt, io, mem};
 
 use serde_core::ser::{

--- a/src/string_record.rs
+++ b/src/string_record.rs
@@ -5,11 +5,8 @@ use std::{
     result, str,
 };
 
-use serde_core::de::Deserialize;
-
 use crate::{
     byte_record::{ByteRecord, ByteRecordIter, Position},
-    deserializer::deserialize_string_record,
     error::{Error, ErrorKind, FromUtf8Error, Result},
     reader::Reader,
 };
@@ -206,6 +203,7 @@ impl StringRecord {
         str_record
     }
 
+    #[cfg(feature = "serde")]
     /// Deserialize this record.
     ///
     /// The `D` type parameter refers to the type that this record should be
@@ -289,11 +287,11 @@ impl StringRecord {
     ///     Ok(())
     /// }
     /// ```
-    pub fn deserialize<'de, D: Deserialize<'de>>(
+    pub fn deserialize<'de, D: serde_core::de::Deserialize<'de>>(
         &'de self,
         headers: Option<&'de StringRecord>,
     ) -> Result<D> {
-        deserialize_string_record(self, headers)
+        crate::deserializer::deserialize_string_record(self, headers)
     }
 
     /// Returns an iterator over all fields in this record.

--- a/src/tutorial.rs
+++ b/src/tutorial.rs
@@ -744,13 +744,14 @@ type: `(String, String, Option<u64>, f64, f64)`.
 
 ```no_run
 //tutorial-read-serde-02.rs
-# #[cfg(feature = "serde")] {
+# #[allow(dead_code)]
 # use std::{error::Error, io, process};
 #
 // This introduces a type alias so that we can conveniently reference our
 // record type.
 type Record = (String, String, Option<u64>, f64, f64);
 
+# #[cfg(feature = "serde")]
 fn run() -> Result<(), Box<dyn Error>> {
     let mut rdr = csv::Reader::from_reader(io::stdin());
     // Instead of creating an iterator with the `records` method, we create
@@ -762,18 +763,17 @@ fn run() -> Result<(), Box<dyn Error>> {
     }
     Ok(())
 }
-#
+
+# #[cfg(feature = "serde")]
 # fn main() {
 #     if let Err(err) = run() {
 #         println!("{}", err);
 #         process::exit(1);
 #     }
 # }
-# }
-# #[cfg(not(feature = "serde"))] {
+# #[cfg(not(feature = "serde"))]
 # fn main() {
 #     println!("this example requires the 'serde' feature");
-# }
 # }
 ```
 
@@ -802,7 +802,7 @@ a new `use` statement that imports `HashMap` from the standard library:
 
 ```no_run
 //tutorial-read-serde-03.rs
-# #[cfg(feature = "serde")] {
+# #[allow(dead_code)]
 use std::collections::HashMap;
 # use std::{error::Error, io, process};
 
@@ -810,6 +810,7 @@ use std::collections::HashMap;
 // record type.
 type Record = HashMap<String, String>;
 
+# #[cfg(feature = "serde")]
 fn run() -> Result<(), Box<dyn Error>> {
     let mut rdr = csv::Reader::from_reader(io::stdin());
     for result in rdr.deserialize() {
@@ -818,18 +819,17 @@ fn run() -> Result<(), Box<dyn Error>> {
     }
     Ok(())
 }
-#
+
+# #[cfg(feature = "serde")]
 # fn main() {
 #     if let Err(err) = run() {
 #         println!("{}", err);
 #         process::exit(1);
 #     }
 # }
-# }
-# #[cfg(not(feature = "serde"))] {
+# #[cfg(not(feature = "serde"))]
 # fn main() {
 #     println!("this example requires the 'serde' feature");
-# }
 # }
 ```
 
@@ -867,10 +867,11 @@ how. Don't miss the new Serde imports!
 ```no_run
 //tutorial-read-serde-04.rs
 # #![allow(dead_code)]
-# #[cfg(feature = "serde")] {
+# #[cfg(feature = "serde")]
 # use std::{error::Error, io, process};
 
 // This lets us write `#[derive(Deserialize)]`.
+# #[cfg(feature = "serde")]
 use serde::Deserialize;
 
 // We don't need to derive `Debug` (which doesn't require Serde), but it's a
@@ -878,6 +879,7 @@ use serde::Deserialize;
 //
 // Notice that the field names in this struct are NOT in the same order as
 // the fields in the CSV data!
+# #[cfg(feature = "serde")]
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 struct Record {
@@ -888,6 +890,7 @@ struct Record {
     state: String,
 }
 
+# #[cfg(feature = "serde")]
 fn run() -> Result<(), Box<dyn Error>> {
     let mut rdr = csv::Reader::from_reader(io::stdin());
     for result in rdr.deserialize() {
@@ -899,12 +902,16 @@ fn run() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
+# #[cfg(feature = "serde")]
 fn main() {
     if let Err(err) = run() {
         println!("{}", err);
         process::exit(1);
     }
 }
+# #[cfg(not(feature = "serde"))]
+# fn main() {
+#     println!("this example requires the 'serde' feature");
 # }
 ```
 
@@ -1006,12 +1013,9 @@ Let's start by running our program from the previous section:
 ```no_run
 //tutorial-read-serde-invalid-01.rs
 # #![allow(dead_code)]
-# #[cfg(feature = "serde")] {
 # use std::{error::Error, io, process};
-#
-# use serde::Deserialize;
-#
-#[derive(Debug, Deserialize)]
+# #[cfg(feature = "serde")]
+#[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "PascalCase")]
 struct Record {
     latitude: f64,
@@ -1021,6 +1025,7 @@ struct Record {
     state: String,
 }
 
+# #[cfg(feature = "serde")]
 fn run() -> Result<(), Box<dyn Error>> {
     let mut rdr = csv::Reader::from_reader(io::stdin());
     for result in rdr.deserialize() {
@@ -1029,13 +1034,16 @@ fn run() -> Result<(), Box<dyn Error>> {
     }
     Ok(())
 }
-#
+# #[cfg(feature = "serde")]
 # fn main() {
 #     if let Err(err) = run() {
 #         println!("{}", err);
 #         process::exit(1);
 #     }
 # }
+# #[cfg(not(feature = "serde"))]
+# fn main() {
+#     println!("this example requires the 'serde' feature");
 # }
 ```
 
@@ -1076,11 +1084,9 @@ to a `None` value, as shown in this next example:
 ```no_run
 //tutorial-read-serde-invalid-02.rs
 # #![allow(dead_code)]
-# #[cfg(feature = "serde")] {
 # use std::{error::Error, io, process};
-#
-# use serde::Deserialize;
-#[derive(Debug, Deserialize)]
+# #[cfg(feature = "serde")]
+#[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "PascalCase")]
 struct Record {
     latitude: f64,
@@ -1090,7 +1096,7 @@ struct Record {
     city: String,
     state: String,
 }
-
+# #[cfg(feature = "serde")]
 fn run() -> Result<(), Box<dyn Error>> {
     let mut rdr = csv::Reader::from_reader(io::stdin());
     for result in rdr.deserialize() {
@@ -1099,18 +1105,16 @@ fn run() -> Result<(), Box<dyn Error>> {
     }
     Ok(())
 }
-#
+# #[cfg(feature = "serde")]
 # fn main() {
 #     if let Err(err) = run() {
 #         println!("{}", err);
 #         process::exit(1);
 #     }
 # }
-# }
-# #[cfg(not(feature = "serde"))] {
+# #[cfg(not(feature = "serde"))]
 # fn main() {
 #     println!("this example requires the 'serde' feature");
-# }
 # }
 ```
 
@@ -1375,9 +1379,8 @@ As with reading, let's start by seeing how we can serialize a Rust tuple.
 
 ```no_run
 //tutorial-write-serde-01.rs
-# #[cfg(feature = "serde")] {
 # use std::{error::Error, io, process};
-#
+# #[cfg(feature = "serde")]
 fn run() -> Result<(), Box<dyn Error>> {
     let mut wtr = csv::Writer::from_writer(io::stdout());
 
@@ -1397,18 +1400,16 @@ fn run() -> Result<(), Box<dyn Error>> {
     wtr.flush()?;
     Ok(())
 }
-#
+# #[cfg(feature = "serde")]
 # fn main() {
 #     if let Err(err) = run() {
 #         println!("{}", err);
 #         process::exit(1);
 #     }
 # }
-# }
-# #[cfg(not(feature = "serde"))] {
+# #[cfg(not(feature = "serde"))]
 # fn main() {
 #     println!("this example requires the 'serde' feature");
-# }
 # }
 ```
 
@@ -1450,13 +1451,11 @@ shown in the example:
 
 ```no_run
 //tutorial-write-serde-02.rs
-# #[cfg(feature = "serde")] {
 use std::{error::Error, io, process};
 
-use serde::Serialize;
-
+# #[cfg(feature = "serde")]
 // Note that structs can derive both Serialize and Deserialize!
-#[derive(Debug, Serialize)]
+#[derive(Debug, serde::Serialize)]
 #[serde(rename_all = "PascalCase")]
 struct Record<'a> {
     city: &'a str,
@@ -1466,6 +1465,7 @@ struct Record<'a> {
     longitude: f64,
 }
 
+# #[cfg(feature = "serde")]
 fn run() -> Result<(), Box<dyn Error>> {
     let mut wtr = csv::Writer::from_writer(io::stdout());
 
@@ -1495,17 +1495,16 @@ fn run() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
+# #[cfg(feature = "serde")]
 fn main() {
     if let Err(err) = run() {
         println!("{}", err);
         process::exit(1);
     }
 }
-# }
-# #[cfg(not(feature = "serde"))] {
+# #[cfg(not(feature = "serde"))]
 # fn main() {
 #     println!("this example requires the 'serde' feature");
-# }
 # }
 ```
 
@@ -1770,14 +1769,12 @@ Now here's the code:
 
 ```no_run
 //tutorial-pipeline-pop-01.rs
-# #[cfg(feature = "serde")] {
 # use std::{env, error::Error, io, process};
 
-use serde::{Deserialize, Serialize};
-
+# #[cfg(feature = "serde")]
 // Unlike previous examples, we derive both Deserialize and Serialize. This
 // means we'll be able to automatically deserialize and serialize this type.
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "PascalCase")]
 struct Record {
     city: String,
@@ -1787,6 +1784,7 @@ struct Record {
     longitude: f64,
 }
 
+# #[cfg(feature = "serde")]
 fn run() -> Result<(), Box<dyn Error>> {
     // Get the query from the positional arguments.
     // If one doesn't exist or isn't an integer, return an error.
@@ -1822,17 +1820,16 @@ fn run() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
+# #[cfg(feature = "serde")]
 fn main() {
     if let Err(err) = run() {
         println!("{}", err);
         process::exit(1);
     }
 }
-# }
-# #[cfg(not(feature = "serde"))] {
+# #[cfg(not(feature = "serde"))]
 # fn main() {
 #     println!("this example requires the 'serde' feature");
-# }
 # }
 ```
 
@@ -2122,12 +2119,10 @@ example using Serde in a previous section:
 ```no_run
 //tutorial-perf-serde-01.rs
 # #![allow(dead_code)]
-# #[cfg(feature = "serde")] {
 use std::{error::Error, io, process};
 
-use serde::Deserialize;
-
-#[derive(Debug, Deserialize)]
+# #[cfg(feature = "serde")]
+#[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "PascalCase")]
 struct Record {
     country: String,
@@ -2139,6 +2134,7 @@ struct Record {
     longitude: f64,
 }
 
+# #[cfg(feature = "serde")]
 fn run() -> Result<u64, Box<dyn Error>> {
     let mut rdr = csv::Reader::from_reader(io::stdin());
 
@@ -2152,6 +2148,7 @@ fn run() -> Result<u64, Box<dyn Error>> {
     Ok(count)
 }
 
+# #[cfg(feature = "serde")]
 fn main() {
     match run() {
         Ok(count) => {
@@ -2163,11 +2160,9 @@ fn main() {
         }
     }
 }
-# }
-# #[cfg(not(feature = "serde"))] {
+# #[cfg(not(feature = "serde"))]
 # fn main() {
 #     println!("this example requires the 'serde' feature");
-# }
 # }
 ```
 
@@ -2197,11 +2192,9 @@ like:
 ```no_run
 //tutorial-perf-serde-02.rs
 # #![allow(dead_code)]
-# #[cfg(feature = "serde")] {
 # use std::{error::Error, io, process};
-# use serde::Deserialize;
-#
-#[derive(Debug, Deserialize)]
+# #[cfg(feature = "serde")]
+#[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "PascalCase")]
 struct Record<'a> {
     country: &'a str,
@@ -2213,6 +2206,7 @@ struct Record<'a> {
     longitude: f64,
 }
 
+# #[cfg(feature = "serde")]
 fn run() -> Result<u64, Box<dyn Error>> {
     let mut rdr = csv::Reader::from_reader(io::stdin());
     let mut raw_record = csv::StringRecord::new();
@@ -2227,7 +2221,8 @@ fn run() -> Result<u64, Box<dyn Error>> {
     }
     Ok(count)
 }
-#
+
+# #[cfg(feature = "serde")]
 # fn main() {
 #     match run() {
 #         Ok(count) => {
@@ -2239,11 +2234,9 @@ fn run() -> Result<u64, Box<dyn Error>> {
 #         }
 #     }
 # }
-# }
-# #[cfg(not(feature = "serde"))] {
+# #[cfg(not(feature = "serde"))]
 # fn main() {
 #     println!("this example requires the 'serde' feature");
-# }
 # }
 ```
 
@@ -2289,12 +2282,10 @@ of `StringRecord`:
 ```no_run
 //tutorial-perf-serde-03.rs
 # #![allow(dead_code)]
-# #[cfg(feature = "serde")] {
 # use std::{error::Error, io, process};
 #
-# use serde::Deserialize;
-#
-#[derive(Debug, Deserialize)]
+# #[cfg(feature = "serde")]
+#[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "PascalCase")]
 struct Record<'a> {
     country: &'a [u8],
@@ -2306,6 +2297,7 @@ struct Record<'a> {
     longitude: f64,
 }
 
+# #[cfg(feature = "serde")]
 fn run() -> Result<u64, Box<dyn Error>> {
     let mut rdr = csv::Reader::from_reader(io::stdin());
     let mut raw_record = csv::ByteRecord::new();
@@ -2320,7 +2312,8 @@ fn run() -> Result<u64, Box<dyn Error>> {
     }
     Ok(count)
 }
-#
+
+# #[cfg(feature = "serde")]
 # fn main() {
 #     match run() {
 #         Ok(count) => {
@@ -2332,11 +2325,9 @@ fn run() -> Result<u64, Box<dyn Error>> {
 #         }
 #     }
 # }
-# }
-# #[cfg(not(feature = "serde"))] {
+# #[cfg(not(feature = "serde"))]
 # fn main() {
 #     println!("this example requires the 'serde' feature");
-# }
 # }
 ```
 

--- a/src/tutorial.rs
+++ b/src/tutorial.rs
@@ -744,6 +744,7 @@ type: `(String, String, Option<u64>, f64, f64)`.
 
 ```no_run
 //tutorial-read-serde-02.rs
+# #[cfg(feature = "serde")] {
 # use std::{error::Error, io, process};
 #
 // This introduces a type alias so that we can conveniently reference our
@@ -767,6 +768,12 @@ fn run() -> Result<(), Box<dyn Error>> {
 #         println!("{}", err);
 #         process::exit(1);
 #     }
+# }
+# }
+# #[cfg(not(feature = "serde"))] {
+# fn main() {
+#     println!("this example requires the 'serde' feature");
+# }
 # }
 ```
 
@@ -795,6 +802,7 @@ a new `use` statement that imports `HashMap` from the standard library:
 
 ```no_run
 //tutorial-read-serde-03.rs
+# #[cfg(feature = "serde")] {
 use std::collections::HashMap;
 # use std::{error::Error, io, process};
 
@@ -816,6 +824,12 @@ fn run() -> Result<(), Box<dyn Error>> {
 #         println!("{}", err);
 #         process::exit(1);
 #     }
+# }
+# }
+# #[cfg(not(feature = "serde"))] {
+# fn main() {
+#     println!("this example requires the 'serde' feature");
+# }
 # }
 ```
 
@@ -853,6 +867,7 @@ how. Don't miss the new Serde imports!
 ```no_run
 //tutorial-read-serde-04.rs
 # #![allow(dead_code)]
+# #[cfg(feature = "serde")] {
 # use std::{error::Error, io, process};
 
 // This lets us write `#[derive(Deserialize)]`.
@@ -890,6 +905,7 @@ fn main() {
         process::exit(1);
     }
 }
+# }
 ```
 
 Compile and run this program to see similar output as before:
@@ -990,6 +1006,7 @@ Let's start by running our program from the previous section:
 ```no_run
 //tutorial-read-serde-invalid-01.rs
 # #![allow(dead_code)]
+# #[cfg(feature = "serde")] {
 # use std::{error::Error, io, process};
 #
 # use serde::Deserialize;
@@ -1018,6 +1035,7 @@ fn run() -> Result<(), Box<dyn Error>> {
 #         println!("{}", err);
 #         process::exit(1);
 #     }
+# }
 # }
 ```
 
@@ -1058,6 +1076,7 @@ to a `None` value, as shown in this next example:
 ```no_run
 //tutorial-read-serde-invalid-02.rs
 # #![allow(dead_code)]
+# #[cfg(feature = "serde")] {
 # use std::{error::Error, io, process};
 #
 # use serde::Deserialize;
@@ -1086,6 +1105,12 @@ fn run() -> Result<(), Box<dyn Error>> {
 #         println!("{}", err);
 #         process::exit(1);
 #     }
+# }
+# }
+# #[cfg(not(feature = "serde"))] {
+# fn main() {
+#     println!("this example requires the 'serde' feature");
+# }
 # }
 ```
 
@@ -1350,6 +1375,7 @@ As with reading, let's start by seeing how we can serialize a Rust tuple.
 
 ```no_run
 //tutorial-write-serde-01.rs
+# #[cfg(feature = "serde")] {
 # use std::{error::Error, io, process};
 #
 fn run() -> Result<(), Box<dyn Error>> {
@@ -1377,6 +1403,12 @@ fn run() -> Result<(), Box<dyn Error>> {
 #         println!("{}", err);
 #         process::exit(1);
 #     }
+# }
+# }
+# #[cfg(not(feature = "serde"))] {
+# fn main() {
+#     println!("this example requires the 'serde' feature");
+# }
 # }
 ```
 
@@ -1418,6 +1450,7 @@ shown in the example:
 
 ```no_run
 //tutorial-write-serde-02.rs
+# #[cfg(feature = "serde")] {
 use std::{error::Error, io, process};
 
 use serde::Serialize;
@@ -1468,6 +1501,12 @@ fn main() {
         process::exit(1);
     }
 }
+# }
+# #[cfg(not(feature = "serde"))] {
+# fn main() {
+#     println!("this example requires the 'serde' feature");
+# }
+# }
 ```
 
 Compiling and running this example has the same output as last time, even
@@ -1731,6 +1770,7 @@ Now here's the code:
 
 ```no_run
 //tutorial-pipeline-pop-01.rs
+# #[cfg(feature = "serde")] {
 # use std::{env, error::Error, io, process};
 
 use serde::{Deserialize, Serialize};
@@ -1788,6 +1828,12 @@ fn main() {
         process::exit(1);
     }
 }
+# }
+# #[cfg(not(feature = "serde"))] {
+# fn main() {
+#     println!("this example requires the 'serde' feature");
+# }
+# }
 ```
 
 If we compile and run our program with a minimum threshold of `100000`, we
@@ -2076,6 +2122,7 @@ example using Serde in a previous section:
 ```no_run
 //tutorial-perf-serde-01.rs
 # #![allow(dead_code)]
+# #[cfg(feature = "serde")] {
 use std::{error::Error, io, process};
 
 use serde::Deserialize;
@@ -2116,6 +2163,12 @@ fn main() {
         }
     }
 }
+# }
+# #[cfg(not(feature = "serde"))] {
+# fn main() {
+#     println!("this example requires the 'serde' feature");
+# }
+# }
 ```
 
 Now compile and run this program:
@@ -2144,6 +2197,7 @@ like:
 ```no_run
 //tutorial-perf-serde-02.rs
 # #![allow(dead_code)]
+# #[cfg(feature = "serde")] {
 # use std::{error::Error, io, process};
 # use serde::Deserialize;
 #
@@ -2184,6 +2238,12 @@ fn run() -> Result<u64, Box<dyn Error>> {
 #             process::exit(1);
 #         }
 #     }
+# }
+# }
+# #[cfg(not(feature = "serde"))] {
+# fn main() {
+#     println!("this example requires the 'serde' feature");
+# }
 # }
 ```
 
@@ -2229,6 +2289,7 @@ of `StringRecord`:
 ```no_run
 //tutorial-perf-serde-03.rs
 # #![allow(dead_code)]
+# #[cfg(feature = "serde")] {
 # use std::{error::Error, io, process};
 #
 # use serde::Deserialize;
@@ -2270,6 +2331,12 @@ fn run() -> Result<u64, Box<dyn Error>> {
 #             process::exit(1);
 #         }
 #     }
+# }
+# }
+# #[cfg(not(feature = "serde"))] {
+# fn main() {
+#     println!("this example requires the 'serde' feature");
+# }
 # }
 ```
 

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -160,11 +160,12 @@ impl WriterBuilder {
     /// names of a struct.
     ///
     /// ```
-    /// # #[cfg(feature = "serde")] {
+    /// # #[allow(dead_code)]
     /// use std::error::Error;
     ///
     /// use csv::WriterBuilder;
     ///
+    /// # #[cfg(feature = "serde")]
     /// #[derive(serde::Serialize)]
     /// struct Row<'a> {
     ///     city: &'a str,
@@ -175,7 +176,9 @@ impl WriterBuilder {
     ///     population: u64,
     /// }
     ///
+    /// # #[cfg(feature = "serde")]
     /// # fn main() { example().unwrap(); }
+    /// # #[cfg(feature = "serde")]
     /// fn example() -> Result<(), Box<dyn Error>> {
     ///     let mut wtr = WriterBuilder::new().from_writer(vec![]);
     ///     wtr.serialize(Row {
@@ -197,7 +200,8 @@ impl WriterBuilder {
     /// ");
     ///     Ok(())
     /// }
-    /// # }
+    /// # #[cfg(not(feature = "serde"))]
+    /// # fn main() {}
     /// ```
     ///
     /// # Example: without headers
@@ -208,11 +212,12 @@ impl WriterBuilder {
     /// explicitly want to both write custom headers and serialize structs.
     ///
     /// ```
-    /// # #[cfg(feature = "serde")] {
     /// use std::error::Error;
     /// use csv::WriterBuilder;
     ///
+    /// # #[cfg(feature = "serde")]
     /// # fn main() { example().unwrap(); }
+    /// # #[cfg(feature = "serde")]
     /// fn example() -> Result<(), Box<dyn Error>> {
     ///     let mut wtr = WriterBuilder::new().from_writer(vec![]);
     ///     wtr.serialize(("Boston", "United States", 4628910))?;
@@ -225,7 +230,8 @@ impl WriterBuilder {
     /// ");
     ///     Ok(())
     /// }
-    /// # }
+    /// # #[cfg(not(feature = "serde"))]
+    /// # fn main() {}
     /// ```
     pub fn has_headers(&mut self, yes: bool) -> &mut WriterBuilder {
         self.has_headers = yes;


### PR DESCRIPTION
Makes the `serde` dependency optional (enabled by default) by gating all serde-related functionality behind a `serde` feature flag.
This PR will make it possible to use `csv` in other crates which offer the `serde` feature flag, and makes the groundwork for adding an optional `std` feature flag which will be necessary to use `csv` with other crates which work with solely `alloc`.

Fixes #412, and replaces the old closed PR https://github.com/BurntSushi/rust-csv/pull/175
