### PR TITLE
Added `#[no_std]` marker to csv core

### DIFF
--- a/csv-core/src/lib.rs
+++ b/csv-core/src/lib.rs
@@ -17,6 +17,7 @@ the `Writer` API provides a CSV writer.
 This example shows how to count the number of fields and records in CSV data.
 
 ```
+#[no_std]
 use csv_core::{Reader, ReadFieldResult};
 
 let data = "


### PR DESCRIPTION
As per title, this simple PR adds the `#[no_std]` marker to the `csv-core` crate. This way, if someone happens to add any std stuff in the crate, they will immediately get an error message about it.