### PR TITLE
Add support for serializing flattened attributes

### DIFF
--- a/src/deserializer.rs
+++ b/src/deserializer.rs
@@ -1206,6 +1206,26 @@ mod tests {
     }
 
     #[test]
+    fn flatten_map() {
+        #[derive(Deserialize, Debug, PartialEq)]
+        struct Row {
+            x: f64,
+            y: f64,
+            #[serde(flatten)]
+            extra: HashMap<String, f64>,
+        }
+
+        let header = StringRecord::from(vec!["x", "y", "prop1", "prop2"]);
+        let record = StringRecord::from(vec!["1", "2", "3", "4"]);
+        let got: Row = record.deserialize(Some(&header)).unwrap();
+        let mut extra = HashMap::new();
+        extra.insert("prop1".to_string(), 3.0);
+        extra.insert("prop2".to_string(), 4.0);
+
+        assert_eq!(got, Row { x: 1.0, y: 2.0, extra });
+    }
+
+    #[test]
     fn partially_invalid_utf8() {
         #[derive(Debug, Deserialize, PartialEq)]
         struct Row {

--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -292,9 +292,9 @@ impl<'a, 'w, W: io::Write> SerializeMap for &'a mut SeRecord<'w, W> {
 
     fn serialize_key<T: ?Sized + Serialize>(
         &mut self,
-        _key: &T,
+        key: &T,
     ) -> Result<(), Self::Error> {
-        Ok(())
+        self.wtr.check_map_key(key)
     }
 
     fn serialize_value<T: ?Sized + Serialize>(
@@ -305,6 +305,7 @@ impl<'a, 'w, W: io::Write> SerializeMap for &'a mut SeRecord<'w, W> {
     }
 
     fn end(self) -> Result<Self::Ok, Self::Error> {
+        self.wtr.on_map_end();
         Ok(())
     }
 }
@@ -742,6 +743,7 @@ impl<'a, 'w, W: io::Write> SerializeMap for &'a mut SeHeader<'w, W> {
             return Err(err);
         }
 
+        self.wtr.check_map_key(key)?;
         let mut key_serializer = SeRecord { wtr: self.wtr };
         key.serialize(&mut key_serializer)?;
         self.state = HeaderState::InStructField;
@@ -763,6 +765,7 @@ impl<'a, 'w, W: io::Write> SerializeMap for &'a mut SeHeader<'w, W> {
     }
 
     fn end(self) -> Result<Self::Ok, Self::Error> {
+        self.wtr.on_map_end();
         Ok(())
     }
 }
@@ -854,6 +857,18 @@ mod tests {
     fn serialize_header_err<S: Serialize>(s: S) -> Error {
         let mut wtr = Writer::from_writer(vec![]);
         s.serialize(&mut SeHeader::new(&mut wtr)).unwrap_err()
+    }
+
+    #[derive(Debug)]
+    struct CustomOrderMap(Vec<(&'static str, f64)>);
+
+    impl Serialize for CustomOrderMap {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            serializer.collect_map(self.0.iter().copied())
+        }
     }
 
     #[test]
@@ -1127,6 +1142,40 @@ mod tests {
     }
 
     #[test]
+    fn ordered_map() {
+        let mut map = BTreeMap::new();
+        map.insert("a", 2.0);
+        map.insert("b", 1.0);
+
+        let got = serialize(&map);
+        assert_eq!(got, "2.0,1.0\n");
+        let (wrote, got) = serialize_header(map);
+        assert!(wrote);
+        assert_eq!(got, "a,b");
+    }
+
+    #[test]
+    fn unordered_map() {
+        let mut writer = Writer::from_writer(vec![]);
+        writer
+            .serialize(CustomOrderMap(vec![("a", 2.0), ("b", 1.0)]))
+            .unwrap();
+        writer
+            .serialize(CustomOrderMap(vec![("a", 3.0), ("b", 4.0)]))
+            .unwrap();
+        writer.flush().unwrap();
+        let csv = String::from_utf8(writer.get_ref().clone()).unwrap();
+        assert_eq!(csv, "a,b\n2.0,1.0\n3.0,4.0\n");
+        let error = writer
+            .serialize(CustomOrderMap(vec![("b", 2.0), ("a", 1.0)])) // Wrong key order
+            .unwrap_err();
+        assert!(
+            matches!(error.kind(), ErrorKind::Serialize(_)),
+            "Got unexpected error: {error}"
+        )
+    }
+
+    #[test]
     fn struct_no_headers() {
         #[derive(Serialize)]
         struct Foo {
@@ -1392,6 +1441,36 @@ mod tests {
     }
 
     #[test]
+    fn flatten_map_with_different_key_order() {
+        #[derive(Serialize, Debug)]
+        struct Row {
+            x: f64,
+            y: f64,
+            #[serde(flatten)]
+            extra: CustomOrderMap,
+        }
+        let mut writer = Writer::from_writer(vec![]);
+        writer
+            .serialize(Row {
+                x: 1.0,
+                y: 2.0,
+                extra: CustomOrderMap(vec![("extra1", 3.0), ("extra2", 4.0)]),
+            })
+            .unwrap();
+        let error = writer
+            .serialize(Row {
+                x: 1.0,
+                y: 2.0,
+                extra: CustomOrderMap(vec![("extra2", 4.0), ("extra1", 3.0)]),
+            })
+            .unwrap_err();
+        assert!(
+            matches!(error.kind(), ErrorKind::Serialize(_)),
+            "Expected ErrorKind::Serialize but got '{error}'"
+        );
+    }
+
+    #[test]
     fn flatten_map_different_num_entries() {
         #[derive(Clone, Serialize, Debug, PartialEq)]
         struct Row {
@@ -1400,20 +1479,20 @@ mod tests {
             #[serde(flatten)]
             extra: BTreeMap<&'static str, f64>,
         }
-        let mut wtr = Writer::from_writer(vec![]);
+        let mut writer = Writer::from_writer(vec![]);
 
         let mut extra = BTreeMap::new();
         extra.insert("extra1", 3.0);
         extra.insert("extra2", 4.0);
         let row = Row { x: 1.0, y: 2.0, extra };
-        wtr.serialize(row).unwrap();
+        writer.serialize(row).unwrap();
 
         let mut extra = BTreeMap::new();
-        extra.insert("extra3", 3.0);
-        extra.insert("extra4", 4.0);
-        extra.insert("extra5", 5.0);
+        extra.insert("extra1", 3.0);
+        extra.insert("extra2", 4.0);
+        extra.insert("extra3", 5.0);
         let row = Row { x: 1.0, y: 2.0, extra };
-        let error = wtr.serialize(row).unwrap_err();
+        let error = writer.serialize(row).unwrap_err();
         match *error.kind() {
             ErrorKind::UnequalLengths {
                 pos: None,

--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -200,12 +200,7 @@ impl<'a, 'w, W: io::Write> Serializer for &'a mut SeRecord<'w, W> {
         self,
         _len: Option<usize>,
     ) -> Result<Self::SerializeMap, Self::Error> {
-        // The right behavior for serializing maps isn't clear.
-        Err(Error::custom(
-            "serializing maps is not supported, \
-             if you have a use case, please file an issue at \
-             https://github.com/BurntSushi/rust-csv",
-        ))
+        Ok(self)
     }
 
     fn serialize_struct(
@@ -299,18 +294,18 @@ impl<'a, 'w, W: io::Write> SerializeMap for &'a mut SeRecord<'w, W> {
         &mut self,
         _key: &T,
     ) -> Result<(), Self::Error> {
-        unreachable!()
+        Ok(())
     }
 
     fn serialize_value<T: ?Sized + Serialize>(
         &mut self,
-        _value: &T,
+        value: &T,
     ) -> Result<(), Self::Error> {
-        unreachable!()
+        value.serialize(&mut **self)
     }
 
     fn end(self) -> Result<Self::Ok, Self::Error> {
-        unreachable!()
+        Ok(())
     }
 }
 
@@ -646,12 +641,7 @@ impl<'a, 'w, W: io::Write> Serializer for &'a mut SeHeader<'w, W> {
         self,
         _len: Option<usize>,
     ) -> Result<Self::SerializeMap, Self::Error> {
-        // The right behavior for serializing maps isn't clear.
-        Err(Error::custom(
-            "serializing maps is not supported, \
-             if you have a use case, please file an issue at \
-             https://github.com/BurntSushi/rust-csv",
-        ))
+        self.handle_container("map")
     }
 
     fn serialize_struct(
@@ -743,20 +733,37 @@ impl<'a, 'w, W: io::Write> SerializeMap for &'a mut SeHeader<'w, W> {
 
     fn serialize_key<T: ?Sized + Serialize>(
         &mut self,
-        _key: &T,
+        key: &T,
     ) -> Result<(), Self::Error> {
-        unreachable!()
+        // Grab old state and update state to `EncounteredStructField`.
+        let old_state =
+            mem::replace(&mut self.state, HeaderState::EncounteredStructField);
+        if let HeaderState::ErrorIfWrite(err) = old_state {
+            return Err(err);
+        }
+
+        let mut key_serializer = SeRecord { wtr: self.wtr };
+        key.serialize(&mut key_serializer)?;
+        self.state = HeaderState::InStructField;
+        Ok(())
     }
 
     fn serialize_value<T: ?Sized + Serialize>(
         &mut self,
-        _value: &T,
+        value: &T,
     ) -> Result<(), Self::Error> {
-        unreachable!()
+        if !matches!(self.state, HeaderState::InStructField) {
+            return Err(Error::new(ErrorKind::Serialize(
+                "Attempted to serialize value without key".to_string(),
+            )));
+        }
+        value.serialize(&mut **self)?;
+        self.state = HeaderState::EncounteredStructField;
+        Ok(())
     }
 
     fn end(self) -> Result<Self::Ok, Self::Error> {
-        unreachable!()
+        Ok(())
     }
 }
 
@@ -809,6 +816,8 @@ impl<'a, 'w, W: io::Write> SerializeStructVariant for &'a mut SeHeader<'w, W> {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+
     use {bstr::ByteSlice, serde::Serialize};
 
     use crate::{
@@ -1324,5 +1333,96 @@ mod tests {
         let (wrote, got) = serialize_header(row.clone());
         assert!(wrote);
         assert_eq!(got, "label,num,label2,value,empty,label,num");
+    }
+
+    #[test]
+    fn flatten() {
+        #[derive(Clone, Serialize, Debug, PartialEq)]
+        struct Input {
+            x: f64,
+            y: f64,
+        }
+
+        #[derive(Clone, Serialize, Debug, PartialEq)]
+        struct Properties {
+            prop1: f64,
+            prop2: f64,
+        }
+
+        #[derive(Clone, Serialize, Debug, PartialEq)]
+        struct Row {
+            #[serde(flatten)]
+            input: Input,
+            #[serde(flatten)]
+            properties: Properties,
+        }
+        let row = Row {
+            input: Input { x: 1.0, y: 2.0 },
+            properties: Properties { prop1: 3.0, prop2: 4.0 },
+        };
+
+        let got = serialize(row.clone());
+        assert_eq!(got, "1.0,2.0,3.0,4.0\n");
+
+        let (wrote, got) = serialize_header(row.clone());
+        assert!(wrote);
+        assert_eq!(got, "x,y,prop1,prop2");
+    }
+
+    #[test]
+    fn flatten_map() {
+        #[derive(Clone, Serialize, Debug, PartialEq)]
+        struct Row {
+            x: f64,
+            y: f64,
+            #[serde(flatten)]
+            extra: BTreeMap<&'static str, f64>,
+        }
+        let mut extra = BTreeMap::new();
+        extra.insert("extra1", 3.0);
+        extra.insert("extra2", 4.0);
+        let row = Row { x: 1.0, y: 2.0, extra };
+
+        let got = serialize(row.clone());
+        assert_eq!(got, format!("1.0,2.0,3.0,4.0\n"));
+
+        let (wrote, got) = serialize_header(row.clone());
+        assert!(wrote);
+        assert_eq!(got, format!("x,y,extra1,extra2"));
+    }
+
+    #[test]
+    fn flatten_map_different_num_entries() {
+        #[derive(Clone, Serialize, Debug, PartialEq)]
+        struct Row {
+            x: f64,
+            y: f64,
+            #[serde(flatten)]
+            extra: BTreeMap<&'static str, f64>,
+        }
+        let mut wtr = Writer::from_writer(vec![]);
+
+        let mut extra = BTreeMap::new();
+        extra.insert("extra1", 3.0);
+        extra.insert("extra2", 4.0);
+        let row = Row { x: 1.0, y: 2.0, extra };
+        wtr.serialize(row).unwrap();
+
+        let mut extra = BTreeMap::new();
+        extra.insert("extra3", 3.0);
+        extra.insert("extra4", 4.0);
+        extra.insert("extra5", 5.0);
+        let row = Row { x: 1.0, y: 2.0, extra };
+        let error = wtr.serialize(row).unwrap_err();
+        match *error.kind() {
+            ErrorKind::UnequalLengths {
+                pos: None,
+                expected_len: 4,
+                len: 5,
+            } => {}
+            ref x => {
+                panic!("expected ErrorKind::UnequalLengths but got '{x:?}'")
+            }
+        }
     }
 }

--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -744,9 +744,15 @@ impl<'a, 'w, W: io::Write> SerializeMap for &'a mut SeHeader<'w, W> {
         }
 
         self.wtr.check_map_key(key)?;
+        self.state = HeaderState::InStructField;
+        key.serialize(&mut **self)?; // This does not actually serialize anything, just checks that the key is a scalar value.
+        if let HeaderState::ErrorIfWrite(err) =
+            mem::replace(&mut self.state, HeaderState::InStructField)
+        {
+            return Err(err);
+        }
         let mut key_serializer = SeRecord { wtr: self.wtr };
         key.serialize(&mut key_serializer)?;
-        self.state = HeaderState::InStructField;
         Ok(())
     }
 
@@ -1152,6 +1158,24 @@ mod tests {
         let (wrote, got) = serialize_header(map);
         assert!(wrote);
         assert_eq!(got, "a,b");
+    }
+
+    #[test]
+    fn ordered_map_with_collection_as_key() {
+        #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
+        struct MyKey {
+            name: &'static str,
+            other_attribute: u8,
+        }
+
+        let mut map = BTreeMap::new();
+        map.insert(MyKey { name: "a", other_attribute: 1 }, 2.0);
+
+        let error = serialize_header_err(map);
+        assert!(
+            matches!(error.kind(), ErrorKind::Serialize(_)),
+            "Expected ErrorKind::Serialize but got '{error}'"
+        );
     }
 
     #[test]

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -540,6 +540,15 @@ pub struct Writer<W: io::Write> {
     state: WriterState,
 }
 
+/// State for tracking headers while writing.
+#[derive(Debug)]
+struct HeaderTrackingState {
+    /// The serialized headers in their expected order.
+    expected_headers: Vec<Vec<u8>>,
+    /// The index into the `expected_headers` list of the next expected header.
+    next_expected_index: usize,
+}
+
 #[derive(Debug)]
 struct WriterState {
     /// Whether the Serde serializer should attempt to write a header row.
@@ -557,6 +566,9 @@ struct WriterState {
     /// immediately after flushing the buffer. This avoids flushing the buffer
     /// twice if the inner writer panics.
     panicked: bool,
+    /// Header tracking state for map like data, to ensure that column order
+    /// is preserved across all rows.
+    header_tracking: Option<HeaderTrackingState>,
 }
 
 /// HeaderState encodes a small state machine for handling header writes.
@@ -638,6 +650,10 @@ impl<W: io::Write> Writer<W> {
                 first_field_count: None,
                 fields_written: 0,
                 panicked: false,
+                header_tracking: Some(HeaderTrackingState {
+                    expected_headers: Vec::new(),
+                    next_expected_index: 0,
+                }),
             },
         }
     }
@@ -1179,6 +1195,47 @@ impl<W: io::Write> Writer<W> {
             }
         }
         Ok(())
+    }
+
+    /// Track the `key` of a map entry. If this is not the first row, also verify that the
+    /// `key` matches the expected next key.
+    pub(crate) fn check_map_key<T: ?Sized + Serialize>(
+        &mut self,
+        key: &T,
+    ) -> Result<()> {
+        let Some(tracking) = &mut self.state.header_tracking else {
+            return Ok(());
+        };
+        let mut encoded_key_serializer = Writer::from_writer(Vec::new());
+        serialize(&mut encoded_key_serializer, key)?;
+        let encoded_key =
+            encoded_key_serializer.into_inner().map_err(|error| {
+                Error::new(ErrorKind::Serialize(format!(
+                    "Failed to serialize key to bytes: {error:?}"
+                )))
+            })?;
+        if let Some(expected_key) =
+            tracking.expected_headers.get(tracking.next_expected_index)
+        {
+            if expected_key != &encoded_key {
+                return Err(Error::new(ErrorKind::Serialize(format!(
+                    "Out of order key `{}`",
+                    String::from_utf8_lossy(&encoded_key)
+                ))));
+            }
+        } else {
+            // Even if this is not the first row, accept more keys. If the writer is flexible then adding more fields is allowed.
+            tracking.expected_headers.push(encoded_key);
+        }
+        tracking.next_expected_index += 1;
+        Ok(())
+    }
+
+    /// Reset the map key tracking at the end of a row.
+    pub(crate) fn on_map_end(&mut self) {
+        if let Some(tracking) = &mut self.state.header_tracking {
+            tracking.next_expected_index = 0;
+        }
     }
 }
 


### PR DESCRIPTION
This is a new attempt to add serialization support for maps and flattened fields, since #223 seem to have stalled out. This adds checks to ensure a stable column order.

# Why
There are multiple reasons:
* To support having a row that is made up of nested structs. Sometimes you have some data that is in a struct which is used throughout the program, and you want to write it in csv with an additional column. Currently you would have to create two structs and copy all members of the first struct into the second, which can be annoying for structs with a large number of members:
  <details><summary>Example without this PR</summary>

  ```rust
  struct Data {
      data1: f64,
      // .. // Lots more fields
      data_n: f64,
  }

  #[derive(Serialize)]
  struct Row {
      time: u32, // One extra field for the csv, then a copy of all of the other fields.
      data1: f64,
      // .. // Lots more fields
      data_n: f64,
  }

  impl Row {
      fn from_data(time: u32, value: Data) -> Self {
          Self {
              time,
              data1: value.data1,
              // .. // Lots more fields
              data_n: value.data_n,
          }
      }
  }
  ```
  </details> 

  <details><summary>Example with this PR</summary>

  ```rust
  #[derive(Serialize)]
  struct Data {
      data1: f64,
      // .. // Lots more fields
      data_n: f64,
  }

  #[derive(Serialize)]
  struct Row {
      time: u32, // One extra field for the csv.
      #[serde(flatten)]
      data: Data,
  }

  impl Row {
      fn from_data(time: u32, data: Data) -> Self {
          Self { time, data }
      }
  }
  ```
  </details> 
* To support some dynamic columns that depend on some configuration which is not known at compile-time in addition to some common fields that are known at compiletime.

  <details><summary>Example</summary>

  ```rust
  #[derive(Serialize)]
  struct Row {
      data1: f64,
      // .. // More fields
      #[serde(flatten)]
      extra_fields: BTreeMap<String, f64>,
  }
  ```
  </details> 
* To archive symmetry with the deserializer, which already has support for the `serde(flatten)` attribute, so it's surprising that serializing support does not.

# How
This implementation focusses on minimal impact of serialization performance. Adding serialization support on it's own does not  add any overhead and is implemented in the first commit (30cc9a0227d112d0aa17a7a288bb39a55ad96d54). The required steps are as follows:
* When encountering a map or a struct with a `flatten` member, `serde` will call `serialize_map`. Similar to `serialize_struct` we check that we are not already in the process of serializing a row, so nested maps are not allowed.
* Then, for each entry of the map or member of the stuct, `SerializeMap::serialize_key` and `SerializeMap::serialize_value` is called.
* Finally, `SerializeMap::end` is called.

<details><summary>The flatten attribute works the same way</summary>

[`serde` treats any struct with one or more `flatten` member as a map](https://github.com/serde-rs/serde/blob/e42684f9a773f0bd0d85f293f0a9034c1ba6c984/serde_derive/src/ser.rs#L304-L311), so the following inputs are equivalent to the serializer:
```rust
let mut input = BTreeMap::new();
input.insert("a", 2.0);
input.insert("b", 1.0);
```
```rust
#[derive(Serialize)]
struct Inner {
    b: f64,
}
#[derive(Serialize)]
struct Outer {
    a: f64,
    #[serde(flatten)]
    inner: Inner,
}
let input = Outer { a: 2.0, inner: Inner { b: 1.0 } };
```
```rust
let mut extra = BTreeMap::new();
extra.insert("b", 1.0);
#[derive(Serialize)]
struct Row {
    a: f64,
    #[serde(flatten)]
    extra: BTreeMap<&'static str, f64>,
}
let input = Row { a: 2.0, extra };
```  
</details> 

However, this will fall apart when used with a map that has an unstable entry order, where the order of the entries is not guaranteed, like the `HashMap`. This is why commit 22acfdce90ff399d0b1eea174c3cb7e4bc45843a adds a check that errors when we encounter out of order keys. It does that by keeping a list of serialized keys and comparing each incoming key with the next expected key.

# Alternatives
This implementation only collects keys and checks them for map based data, not for pure structs without `flatten` members. This is done so that this check has no impact when no maps are used, but this means it is still possible to get out of order columns when mixing non-map and map based data:
<details><summary>Example</summary>

```rust
#[derive(Serialize)]
struct Row {
    b: f64,
    a: f64,
}

let mut writer = Writer::from_writer(vec![]);
writer.serialize(Row {
    b: 1.0,
    a: 2.0,
}).unwrap();
let mut map = BTreeMap::new();
map.insert("a", 2.0);
map.insert("b", 1.0);
writer.serialize(map).unwrap();
```
```csv
b,a
1.0,2.0
2.0,1.0
```
</details> 
It is in my opinion very unlikely that anyone will do something like this, nevertheless it would be possible to collect all keys regardless of whether they come from a map or a struct. This would add overhead for non-map based data.

An alternative to generating an error for out of order keys is also to support them by accumulating the serialized values and then writing them out at the end (in `SerializeMap::end`) in the right order. That way `HashMap` would be supported, but we'd loose support for two colums with the same name and we'd need to store the serialized values in addition to the serialized keys.

# Future work
I did not add an option to enable or disable the key order check, but this can be easily added to the builder if we agree on this solution.

-----

I hope this helps to finally bring this feature to the crate. Thank you for your work in maintaining it!